### PR TITLE
Reformatting and code fixes

### DIFF
--- a/src/Apache/Solr/HttpTransport/Curl.php
+++ b/src/Apache/Solr/HttpTransport/Curl.php
@@ -37,7 +37,7 @@
  */
 
 // Require Apache_Solr_HttpTransport_Abstract
-require_once(dirname(__FILE__) . '/Abstract.php');
+require_once(__DIR__ . '/Abstract.php');
 
 /**
  * A Curl based HTTP transport. Uses a single curl session for all requests.

--- a/src/Apache/Solr/HttpTransport/CurlNoReuse.php
+++ b/src/Apache/Solr/HttpTransport/CurlNoReuse.php
@@ -37,7 +37,7 @@
  */
 
 // Require Apache_Solr_HttpTransport_Abstract
-require_once(dirname(__FILE__) . '/Abstract.php');
+require_once(__DIR__ . '/Abstract.php');
 
 /**
  * An alternative Curl HTTP transport that opens and closes a curl session for

--- a/src/Apache/Solr/HttpTransport/FileGetContents.php
+++ b/src/Apache/Solr/HttpTransport/FileGetContents.php
@@ -37,7 +37,7 @@
  */
 
 // Require Apache_Solr_HttpTransport_Abstract
-require_once(dirname(__FILE__) . '/Abstract.php');
+require_once(__DIR__ . '/Abstract.php');
 
 /**
  * HTTP Transport implemenation that uses the builtin http URL wrappers and file_get_contents

--- a/src/Apache/Solr/HttpTransport/Interface.php
+++ b/src/Apache/Solr/HttpTransport/Interface.php
@@ -37,7 +37,7 @@
  */
 
 // require Apache_Solr_HttpTransport_Response
-require_once(dirname(__FILE__) . '/Response.php');
+require_once(__DIR__ . '/Response.php');
 
 /**
  * Interface that all Transport (HTTP Requester) implementations must implement. These

--- a/src/Apache/Solr/Response.php
+++ b/src/Apache/Solr/Response.php
@@ -36,7 +36,7 @@
  * @author Donovan Jimenez <djimenez@conduit-it.com>
  */
 
-require_once(dirname(__FILE__) . '/ParserException.php');
+require_once(__DIR__ . '/ParserException.php');
 
 /**
  * Represents a Solr response.  Parses the raw response into a set of stdClass objects

--- a/src/Apache/Solr/Service.php
+++ b/src/Apache/Solr/Service.php
@@ -38,14 +38,14 @@
 
 // See Issue #1 (http://code.google.com/p/solr-php-client/issues/detail?id=1)
 // Doesn't follow typical include path conventions, but is more convenient for users
-require_once(dirname(__FILE__) . '/Exception.php');
-require_once(dirname(__FILE__) . '/HttpTransportException.php');
-require_once(dirname(__FILE__) . '/InvalidArgumentException.php');
+require_once(__DIR__ . '/Exception.php');
+require_once(__DIR__ . '/HttpTransportException.php');
+require_once(__DIR__ . '/InvalidArgumentException.php');
 
-require_once(dirname(__FILE__) . '/Document.php');
-require_once(dirname(__FILE__) . '/Response.php');
+require_once(__DIR__ . '/Document.php');
+require_once(__DIR__ . '/Response.php');
 
-require_once(dirname(__FILE__) . '/HttpTransport/Interface.php');
+require_once(__DIR__ . '/HttpTransport/Interface.php');
 
 /**
  * Starting point for the Solr API. Represents a Solr server resource and has
@@ -476,7 +476,7 @@ class Apache_Solr_Service
 		// lazy load a default if one has not be set
 		if ($this->_httpTransport === false)
 		{
-			require_once(dirname(__FILE__) . '/HttpTransport/FileGetContents.php');
+			require_once(__DIR__ . '/HttpTransport/FileGetContents.php');
 
 			$this->_httpTransport = new Apache_Solr_HttpTransport_FileGetContents();
 		}

--- a/src/Apache/Solr/Service/Balancer.php
+++ b/src/Apache/Solr/Service/Balancer.php
@@ -38,9 +38,9 @@
 
 // See Issue #1 (http://code.google.com/p/solr-php-client/issues/detail?id=1)
 // Doesn't follow typical include path conventions, but is more convenient for users
-require_once(dirname(dirname(__FILE__)) . '/Service.php');
+require_once(dirname(__DIR__) . '/Service.php');
 
-require_once(dirname(dirname(__FILE__)) . '/NoServiceAvailableException.php');
+require_once(dirname(__DIR__) . '/NoServiceAvailableException.php');
 
 /**
  * Reference Implementation for using multiple Solr services in a distribution. Functionality

--- a/src/config/config.facets.php
+++ b/src/config/config.facets.php
@@ -1,31 +1,100 @@
 <?php
 // do not config here, this config file will be overwritten by Thesaurus and Ontologies Manager
 
-$cfg['facets']['author_s'] = array ('label'=>'Author', 'facet_limit'=>'10', 'snippets_limit'=>'10','snippets_enabled'=>true);
+$cfg['facets']['author_s'] = array(
+  'label' => 'Author',
+  'facet_limit' => '10',
+  'snippets_limit' => '10',
+  'snippets_enabled' => TRUE
+);
 
-$cfg['facets']['tag_ss'] = array ('label'=>'Tags', 'facet_limit'=>'10', 'snippets_limit'=>'10','snippets_enabled'=>true);
+$cfg['facets']['tag_ss'] = array(
+  'label' => 'Tags',
+  'facet_limit' => '10',
+  'snippets_limit' => '10',
+  'snippets_enabled' => TRUE
+);
 
-$cfg['facets']['person_ss'] = array ('label'=>'Persons', 'facet_limit'=>'10', 'snippets_limit'=>'10','snippets_enabled'=>true);
+$cfg['facets']['person_ss'] = array(
+  'label' => 'People',
+  'facet_limit' => '10',
+  'snippets_limit' => '10',
+  'snippets_enabled' => TRUE
+);
 
-$cfg['facets']['organization_ss'] = array ('label'=>'Organizations', 'facet_limit'=>'10', 'snippets_limit'=>'10','snippets_enabled'=>true);
+$cfg['facets']['organization_ss'] = array(
+  'label' => 'Organizations',
+  'facet_limit' => '10',
+  'snippets_limit' => '10',
+  'snippets_enabled' => TRUE
+);
 
-$cfg['facets']['location_ss'] = array ('label'=>'Location', 'facet_limit'=>'10', 'snippets_limit'=>'10','snippets_enabled'=>true);
+$cfg['facets']['location_ss'] = array(
+  'label' => 'Location',
+  'facet_limit' => '10',
+  'snippets_limit' => '10',
+  'snippets_enabled' => TRUE
+);
 
-$cfg['facets']['language_s'] = array ('label'=>'Language', 'facet_limit'=>'10', 'snippets_limit'=>'10','snippets_enabled'=>false);
+$cfg['facets']['language_s'] = array(
+  'label' => 'Language',
+  'facet_limit' => '10',
+  'snippets_limit' => '10',
+  'snippets_enabled' => FALSE
+);
 
-$cfg['facets']['email_ss'] = array ('label'=>'Email', 'facet_limit'=>'10', 'snippets_limit'=>'10','snippets_enabled'=>true);
+$cfg['facets']['email_ss'] = array(
+  'label' => 'Email',
+  'facet_limit' => '10',
+  'snippets_limit' => '10',
+  'snippets_enabled' => TRUE
+);
 
-$cfg['facets']['message_from_ss'] = array ('label'=>'Message from', 'facet_limit'=>'10', 'snippets_limit'=>'10','snippets_enabled'=>true);
+$cfg['facets']['message_from_ss'] = array(
+  'label' => 'Message from',
+  'facet_limit' => '10',
+  'snippets_limit' => '10',
+  'snippets_enabled' => TRUE
+);
 
-$cfg['facets']['message_to_ss'] = array ('label'=>'Message to', 'facet_limit'=>'10', 'snippets_limit'=>'10','snippets_enabled'=>true);
+$cfg['facets']['message_to_ss'] = array(
+  'label' => 'Message to',
+  'facet_limit' => '10',
+  'snippets_limit' => '10',
+  'snippets_enabled' => TRUE
+);
 
-$cfg['facets']['message_cc_ss'] = array ('label'=>'Message CC', 'facet_limit'=>'10', 'snippets_limit'=>'10','snippets_enabled'=>true);
+$cfg['facets']['message_cc_ss'] = array(
+  'label' => 'Message CC',
+  'facet_limit' => '10',
+  'snippets_limit' => '10',
+  'snippets_enabled' => TRUE
+);
 
-$cfg['facets']['message_bcc_ss'] = array ('label'=>'Message BCC', 'facet_limit'=>'10', 'snippets_limit'=>'10','snippets_enabled'=>true);
+$cfg['facets']['message_bcc_ss'] = array(
+  'label' => 'Message BCC',
+  'facet_limit' => '10',
+  'snippets_limit' => '10',
+  'snippets_enabled' => TRUE
+);
 
-$cfg['facets']['hashtag_ss'] = array ('label'=>'Hashtags', 'facet_limit'=>'10', 'snippets_limit'=>'10','snippets_enabled'=>true);
+$cfg['facets']['hashtag_ss'] = array(
+  'label' => 'Hashtags',
+  'facet_limit' => '10',
+  'snippets_limit' => '10',
+  'snippets_enabled' => TRUE
+);
 
-$cfg['facets']['content_type_group'] = array ('label'=>'Content type group', 'facet_limit'=>'10', 'snippets_limit'=>'10','snippets_enabled'=>false);
+$cfg['facets']['content_type_group'] = array(
+  'label' => 'Content type group',
+  'facet_limit' => '10',
+  'snippets_limit' => '10',
+  'snippets_enabled' => FALSE
+);
 
-$cfg['facets']['content_type'] = array ('label'=>'Content type', 'facet_limit'=>'10', 'snippets_limit'=>'10','snippets_enabled'=>false);
-?>
+$cfg['facets']['content_type'] = array(
+  'label' => 'Content type',
+  'facet_limit' => '10',
+  'snippets_limit' => '10',
+  'snippets_enabled' => FALSE
+);

--- a/src/config/config.i18n.php
+++ b/src/config/config.i18n.php
@@ -40,21 +40,21 @@ $lang['en']['view_trend'] = 'Trend';
 $lang['en']['file_size'] = 'Filesize';
 
 $lang['en']['content type'] = 'Content type';
-$lang['en']['content_ocr'] = "Automatic text recognition (OCR) from image(s):";
+$lang['en']['content_ocr'] = 'Automatic text recognition (OCR) from image(s):';
 
 // Field labels
-$lang['en']['ocr_t'] = "OCR";
-$lang['en']['title'] = "Title";
-$lang['en']['author_s'] = "Author";
-$lang['en']['content_type'] = "Content type";
-$lang['en']['file_modified_dt'] = "File modified";
-$lang['en']['last_modified'] = "Last modified";
-$lang['en']['file_size_i'] = "Size (bytes)";
+$lang['en']['ocr_t'] = 'OCR';
+$lang['en']['title'] = 'Title';
+$lang['en']['author_s'] = 'Author';
+$lang['en']['content_type'] = 'Content type';
+$lang['en']['file_modified_dt'] = 'File modified';
+$lang['en']['last_modified'] = 'Last modified';
+$lang['en']['file_size_i'] = 'Size (bytes)';
 
-$lang['en']['view_words'] = "Words (list of words and word cloud)";
+$lang['en']['view_words'] = 'Words (list of words and word cloud)';
 $lang['en']['view_analytics'] = 'Analyze';
 
-$lang['en']['Words'] = "Words (count of docs)";
+$lang['en']['Words'] = 'Words (count of docs)';
 
 //
 // German (de)
@@ -94,7 +94,7 @@ $lang['de']['Paths'] = 'Dateiverzeichnisse';
 // view labels
 $lang['de']['Images'] = 'Bilder';
 $lang['de']['Table'] = 'Tabelle';
-$lang['de']['view_words'] = "Wörter";
+$lang['de']['view_words'] = 'Wörter';
 $lang['de']['view_analytics'] = 'Analyse';
 // Sort labels
 
@@ -115,11 +115,11 @@ $lang['de']['content type group'] = 'Formen';
 $lang['de']['content type'] = 'Dateiformate';
 
 
-$lang['de']['content_ocr'] = "Automatisch erkannter Text (OCR) aus Grafikdatei(en):";
+$lang['de']['content_ocr'] = 'Automatisch erkannter Text (OCR) aus Grafikdatei(en):';
 
 $lang['de']['file_size'] = 'Dateigrösse';
 
-$lang['de']['Words'] = "Wörter (Dokumente)";
+$lang['de']['Words'] = 'Wörter (Dokumente)';
 
 
 
@@ -141,5 +141,3 @@ function t($string) {
 
 	return $result;
 }
-
-?>

--- a/src/config/config.mimetypes.php
+++ b/src/config/config.mimetypes.php
@@ -1,36 +1,42 @@
 <?php
 
-$mimetypes=array(
+$mimetypes = array(
 
-		// Mimetypes
-		'image' => array ('name'=>'Image', 'icon'=>'jpeg.png'),
-		'video' => array ('name'=>'Video', 'icon'=>'jpeg.png'),
-		'text' => array ('name'=>'Text', 'icon'=>'jpeg.png'),
-		'html' => array ('name'=>'HTML', 'icon'=>'html.png'),
-		'text/html' => array ('name'=>'HTML', 'icon'=>'html.png'),
-		'text/plain' => array ('name'=>'TXT', 'icon'=>'txt.png'),
-		'text/xml' => array ('name'=>'XML', 'icon'=>'xml.png'),
-		'image/gif' => array ('name'=>'GIF', 'icon'=>'gif.png'),
-		'image/png' => array ('name'=>'PNG', 'icon'=>'png.png'),
-		'image/jpeg' => array ('name'=>'JPEG', 'icon'=>'jpeg.png'),
-		'application/xml' => array ('name'=>'XML', 'icon'=>'xml.png'),
-		'application/pdf' => array ('name'=>'PDF', 'icon'=>'pdf.png'),
-		'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => array ('name'=>'Word', 'icon'=>'doc.png'),
-		'application/vnd.openxmlformats-officedocument.wordprocessingml.template' => array ('name'=>'Word template', 'icon'=>'doc.png'),
-		'application/msword' => array ('name'=>'Word (old format)', 'icon'=>'doc.png'),
-		'application/vnd.openxmlformats-officedocument.presentationml.presentation' => array ('name'=>'Powerpoint', 'icon'=>'archive.png'),
-		'application/vnd.openxmlformats-officedocument.presentationml.template' => array ('name'=>'Powerpoint template', 'icon'=>'archive.png'),
-		'application/vnd.ms-powerpoint' => array ('name'=>'Powerpoint (old format)', 'icon'=>'archive.png'),
-		'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => array ('name'=>'Excel', 'icon'=>'archive.png'),
-		'application/vnd.openxmlformats-officedocument.spreadsheetml.template' => array ('name'=>'Excel template', 'icon'=>'archive.png'),
-		'application/vnd.ms-excel' => array ('name'=>'Excel (old format)', 'icon'=>'archive.png'),
-		'application/vnd.oasis.opendocument.text' => array ('name'=>'OpenOffice Text', 'icon'=>'odf.png'),
-		'application/vnd.oasis.opendocument.text-template' => array ('name'=>'OpenOffice Text template', 'icon'=>'odf.png'),
-		'application/vnd.oasis.opendocument.spreadsheet' => array ('name'=>'OpenOffice Calc', 'icon'=>'odf.png'),
-		'application/vnd.oasis.opendocument.spreadsheet-template' => array ('name'=>'OpenOffice Calc template', 'icon'=>'odf.png'),
-		'application/vnd.oasis.opendocument.presentation' => array ('name'=>'OpenOffice Presenter', 'icon'=>'archive.png'),
-		'application/vnd.oasis.opendocument.presentation-template' => array ('name'=>'OpenOffice Presenter template', 'icon'=>'archive.png'),
-		'application/zip' => array ('name'=>'ZIP', 'icon'=>'archive.png'),
-		'application/rtf' => array ('name'=>'RTF', 'icon'=>'rtf.png'),
-);
-?>
+// Mimetypes
+  'image' => array ('name'=>'Image', 'icon'=>'jpeg.png'),
+  'video' => array ('name'=>'Video', 'icon'=>'jpeg.png'),
+  'text' => array ('name'=>'Text', 'icon'=>'jpeg.png'),
+  'html' => array ('name'=>'HTML', 'icon'=>'html.png'),
+
+  'text/html' => array ('name'=>'HTML', 'icon'=>'html.png'),
+  'text/plain' => array ('name'=>'TXT', 'icon'=>'txt.png'),
+  'text/xml' => array ('name'=>'XML', 'icon'=>'xml.png'),
+
+  'image/gif' => array ('name'=>'GIF', 'icon'=>'gif.png'),
+  'image/png' => array ('name'=>'PNG', 'icon'=>'png.png'),
+  'image/jpeg' => array ('name'=>'JPEG', 'icon'=>'jpeg.png'),
+
+  'application/xml' => array ('name'=>'XML', 'icon'=>'xml.png'),
+  'application/pdf' => array ('name'=>'PDF', 'icon'=>'pdf.png'),
+  'application/zip' => array ('name'=>'ZIP', 'icon'=>'archive.png'),
+  'application/rtf' => array ('name'=>'RTF', 'icon'=>'rtf.png'),
+
+  'application/msword' => array ('name'=>'Word (old format)', 'icon'=>'doc.png'),
+  'application/vnd.ms-excel' => array ('name'=>'Excel (old format)', 'icon'=>'archive.png'),
+  'application/vnd.ms-powerpoint' => array ('name'=>'Powerpoint (old format)', 'icon'=>'archive.png'),
+
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => array ('name'=>'Word', 'icon'=>'doc.png'),
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.template' => array ('name'=>'Word template', 'icon'=>'doc.png'),
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation' => array ('name'=>'Powerpoint', 'icon'=>'archive.png'),
+  'application/vnd.openxmlformats-officedocument.presentationml.template' => array ('name'=>'Powerpoint template', 'icon'=>'archive.png'),
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => array ('name'=>'Excel', 'icon'=>'archive.png'),
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.template' => array ('name'=>'Excel template', 'icon'=>'archive.png'),
+
+  'application/vnd.oasis.opendocument.text' => array ('name'=>'OpenOffice Text', 'icon'=>'odf.png'),
+  'application/vnd.oasis.opendocument.text-template' => array ('name'=>'OpenOffice Text template', 'icon'=>'odf.png'),
+  'application/vnd.oasis.opendocument.spreadsheet' => array ('name'=>'OpenOffice Calc', 'icon'=>'odf.png'),
+  'application/vnd.oasis.opendocument.spreadsheet-template' => array ('name'=>'OpenOffice Calc template', 'icon'=>'odf.png'),
+  'application/vnd.oasis.opendocument.presentation' => array ('name'=>'OpenOffice Presenter', 'icon'=>'archive.png'),
+  'application/vnd.oasis.opendocument.presentation-template' => array ('name'=>'OpenOffice Presenter template', 'icon'=>'archive.png'),
+
+  );

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -101,5 +101,3 @@ $cfg['preview_allowed'] = true;
 //
 
 // $cfg['disable_view_words'] = true;
-
-?>

--- a/src/index.php
+++ b/src/index.php
@@ -1096,10 +1096,8 @@ $form_hidden_parameters = buildform($params, 'q', NULL, 's', NULL, 'operator', N
 
 $datevalues = get_datevalues($results, $params, $downzoom);
 
-if (isset($embedded) && $embedded) {
+if (!empty($embedded)) {
 	include "templates/view.embedded.php";
 } else {
 	include "templates/view.index.php";
 }
-
-?>

--- a/src/templates/pagination.php
+++ b/src/templates/pagination.php
@@ -6,84 +6,91 @@
 
 ?>
 
-<div class="row"><hr /></div>
+<div class="row">
+  <hr/>
+</div>
 
 
-<div class="pages" class="row"><ul class="pagination text-center" role="navigation" aria-label="Pagination">
-  <li class="pagination-previous <?php if (! $is_prev_page): print 'disabled'; endif;?>">
-  <?php if ($is_prev_page) { ?>
-  <a onclick="waiting_on();" href="<?php print $link_prev; ?>">
-  <?php } ?>
+<div class="pages" class="row">
+  <ul class="pagination text-center" role="navigation" aria-label="Pagination">
+    <li
+      class="pagination-previous <?php if (!$is_prev_page): print 'disabled'; endif; ?>">
+      <?php if ($is_prev_page) { ?>
+      <a onclick="waiting_on();" href="<?php print $link_prev; ?>">
+        <?php } ?>
 
-  <?php print t('prev') ?>
+        <?php print t('prev') ?>
 
-  <?php if ($is_prev_page) { ?></a><?php } ?>
-  
-  </li>
+        <?php if ($is_prev_page) { ?></a><?php } ?>
 
-  <li>
-  
-  <?php
- 
+    </li>
 
+    <li>
+
+      <?php
 
 
-	if (empty($query) and $start == 1 and !$path) {
-		?>
-	    <?php echo t('newest_documents')?>
-	    
-	    <?= $limit ?>
-	    
-        <?php echo t('newest_documents_of')?>
-	
-	    <?= $total ?>
+      if (empty($query) and $start == 1 and !$path) {
+        ?>
+        <?php echo t('newest_documents') ?>
 
-	    <?php echo t('newest_documents_of_total')?>
-	  <?php
-	
-	  } else {
-	
-	    ?>
-	    
-	    <?php if ($view=="preview") { ?>
+        <?= $limit ?>
 
-	    <?php echo t('result'); ?>
-	    <?= $page ?>
-	    <?php echo t('page of'); ?>
-	    <?= $total ?>
-	    
-	    
-	    <?php } else { ?>
-	    <?php echo t('page'); ?>
-	    <?= $page ?>
-	    <?php echo t('page of'); ?>
-	    <?= $pages ?>
-	    (<?php echo t('results'); ?>
-	    
-	    <?= $start ?>
-	    <?php echo t('result to'); ?>
-	    <?= $end ?>
-	    <?php echo t('result of'); ?>
-	    <?= $total ?>
-	    )
-	    <?php
-	    }
-	    
-	  }
-		
-	
-?>
-  </li>
+        <?php echo t('newest_documents_of') ?>
 
-  <li class="pagination-next <?php if (! $is_next_page): print 'disabled'; endif;?>">
-  <?php if ($is_next_page) { ?>
-  <a onclick="waiting_on();" href="<?php print $link_next; ?>">
-  <?php } ?>
+        <?= $total ?>
 
-  <?php print t('next') ?>
+        <?php echo t('newest_documents_of_total') ?>
+        <?php
 
-  <?php if ($is_next_page) { ?></a><?php } ?>
-  
-  </li> 
-  </ul></div>
-<div class="row"><hr /></div>
+      }
+      else {
+
+        ?>
+
+        <?php if ($view == "preview") { ?>
+
+          <?php echo t('result'); ?>
+          <?= $page ?>
+          <?php echo t('page of'); ?>
+          <?= $total ?>
+
+
+        <?php } else { ?>
+          <?php echo t('page'); ?>
+          <?= $page ?>
+          <?php echo t('page of'); ?>
+          <?= $pages ?>
+          (<?php echo t('results'); ?>
+
+          <?= $start ?>
+          <?php echo t('result to'); ?>
+          <?= $end ?>
+          <?php echo t('result of'); ?>
+          <?= $total ?>
+          )
+          <?php
+        }
+
+      }
+
+
+      ?>
+    </li>
+
+    <li
+      class="pagination-next <?php if (!$is_next_page): print 'disabled'; endif; ?>">
+      <?php if ($is_next_page) { ?>
+      <a onclick="waiting_on();" href="<?php print $link_next; ?>">
+        <?php } ?>
+
+        <?php print t('next') ?>
+
+        <?php if ($is_next_page) { ?></a><?php } ?>
+
+    </li>
+  </ul>
+</div>
+<div class="row">
+  <hr/>
+</div>

--- a/src/templates/select_sort.php
+++ b/src/templates/select_sort.php
@@ -1,59 +1,57 @@
 <?php
-  
+
 // Show sort selectors
-  
+
 if ($view != "words" && $view != 'trend') {
-	
-?>
-	<div id="sort" class="row float-right">
 
-	        <script type="text/javascript">
-        function handleSelectSort() {
-        	waiting_on();
-            window.location = document.getElementById( 'select_sort' ).value ;
-        } 
-        </script>
-<label>Sort
-  <select id="select_sort" onchange="handleSelectSort()">
-    
-    		<?php 
-		if (is_null($sort)) {
-			print '<option selected value="' . buildurl($params, "sort", NULL, 's', 1) . '">' . t('Relevance') . '</option>';
-		} else {
-			print '<option value="' . buildurl($params, "sort", NULL, 's', 1) . '">' . t('Relevance') . '</option>';
-		}
-		if ($sort == 'newest') {
-			print '<option selected value="' . buildurl($params, "sort", 'newest', 's', 1) . '">' . t('Newest') . '</option>';
-		} else {
-			print '<option value="' . buildurl($params, "sort", 'newest', 's', 1) . '">' . t('Newest') . '</option>';
-		}
-		if ($sort == 'oldest') {
-			print '<option selected value="' . buildurl($params, "sort", 'oldest', 's', 1) . '">' . t('Oldest') . '</option>';
-		} else {
-			print '<option value="' . buildurl($params, "sort", 'oldest', 's', 1) . '">' . t('Oldest') . '</option>';
-		}
-		
-		if ($sort != NULL && $sort != 'newest' && $sort != 'oldest') {
-		
-			print '<option selected value="' . buildurl($params, "sort", $sort, 's', 1) . '">' . htmlspecialchars($sort) . '</option>';
-				
-		}
-		?>
-    
-    
-  </select>
-</label>
+  ?>
+  <div id="sort" class="row float-right">
 
-		
-		
-		
-		</div>
+    <script type="text/javascript">
+      function handleSelectSort() {
+        waiting_on();
+        window.location = document.getElementById('select_sort').value;
+      }
+    </script>
+    <label>Sort
+      <select id="select_sort" onchange="handleSelectSort()">
 
-    
-		
-		
-		
-<?php
+        <?php
+        if (is_null($sort)) {
+          print '<option selected value="' . buildurl($params, "sort", NULL, 's', 1) . '">' . t('Relevance') . '</option>';
+        }
+        else {
+          print '<option value="' . buildurl($params, "sort", NULL, 's', 1) . '">' . t('Relevance') . '</option>';
+        }
+        if ($sort == 'newest') {
+          print '<option selected value="' . buildurl($params, "sort", 'newest', 's', 1) . '">' . t('Newest') . '</option>';
+        }
+        else {
+          print '<option value="' . buildurl($params, "sort", 'newest', 's', 1) . '">' . t('Newest') . '</option>';
+        }
+        if ($sort == 'oldest') {
+          print '<option selected value="' . buildurl($params, "sort", 'oldest', 's', 1) . '">' . t('Oldest') . '</option>';
+        }
+        else {
+          print '<option value="' . buildurl($params, "sort", 'oldest', 's', 1) . '">' . t('Oldest') . '</option>';
+        }
+
+        if ($sort != NULL && $sort != 'newest' && $sort != 'oldest') {
+
+          print '<option selected value="' . buildurl($params, "sort", $sort, 's', 1) . '">' . htmlspecialchars($sort) . '</option>';
+
+        }
+        ?>
+
+
+      </select>
+    </label>
+
+
+  </div>
+
+
+  <?php
 
 }
 

--- a/src/templates/select_sort.php
+++ b/src/templates/select_sort.php
@@ -1,58 +1,34 @@
-<?php
-
-// Show sort selectors
-
-if ($view != "words" && $view != 'trend') {
-
-  ?>
+<?php if ($view != "words" && $view != 'trend'): ?>
   <div id="sort" class="row float-right">
+    <label for="select_sort"><?= t('Sort') ?></label>
+    <select id="select_sort">
 
+      <?php $sort_relevance = (is_null($sort)) ? 'selected' : ''; ?>
+      <option <?= $sort_relevance ?>
+        value="<?= buildurl($params, "sort", NULL, 's', 1) ?>"><?= t('Relevance') ?></option>
+      '
+
+      <?php $sort_newest = (isset($sort) && $sort == 'newest') ? 'selected' : ''; ?>
+      <option <?= $sort_newest ?>
+        value="<?= buildurl($params, "sort", 'newest', 's', 1) ?>"><?= t('Newest') ?></option>
+
+      <?php $sort_oldest = (isset($sort) && $sort == 'oldest') ? 'selected' : ''; ?>
+      <option <?= $sort_oldest ?>
+        value="<?= buildurl($params, "sort", 'oldest', 's', 1) ?>"><?= t('Oldest') ?></option>
+
+      <?php $sort_other = ($sort != NULL && $sort != 'newest' && $sort != 'oldest') ? 'selected' : ''; ?>
+      <option <?= $sort_other ?>
+        value="<?= buildurl($params, "sort", $sort, 's', 1) ?>"><?= htmlspecialchars($sort) ?></option>
+
+    </select>
     <script type="text/javascript">
-      function handleSelectSort() {
+      //$.ready(function () {
+      $('#select_sort').change(function () {
+        var dest = $(this).val();
         waiting_on();
-        window.location = document.getElementById('select_sort').value;
-      }
+        window.location = dest;
+      });
+      //});
     </script>
-    <label>Sort
-      <select id="select_sort" onchange="handleSelectSort()">
-
-        <?php
-        if (is_null($sort)) {
-          print '<option selected value="' . buildurl($params, "sort", NULL, 's', 1) . '">' . t('Relevance') . '</option>';
-        }
-        else {
-          print '<option value="' . buildurl($params, "sort", NULL, 's', 1) . '">' . t('Relevance') . '</option>';
-        }
-        if ($sort == 'newest') {
-          print '<option selected value="' . buildurl($params, "sort", 'newest', 's', 1) . '">' . t('Newest') . '</option>';
-        }
-        else {
-          print '<option value="' . buildurl($params, "sort", 'newest', 's', 1) . '">' . t('Newest') . '</option>';
-        }
-        if ($sort == 'oldest') {
-          print '<option selected value="' . buildurl($params, "sort", 'oldest', 's', 1) . '">' . t('Oldest') . '</option>';
-        }
-        else {
-          print '<option value="' . buildurl($params, "sort", 'oldest', 's', 1) . '">' . t('Oldest') . '</option>';
-        }
-
-        if ($sort != NULL && $sort != 'newest' && $sort != 'oldest') {
-
-          print '<option selected value="' . buildurl($params, "sort", $sort, 's', 1) . '">' . htmlspecialchars($sort) . '</option>';
-
-        }
-        ?>
-
-
-      </select>
-    </label>
-
-
   </div>
-
-
-  <?php
-
-}
-
-?>
+<?php endif; ?>

--- a/src/templates/select_view.php
+++ b/src/templates/select_view.php
@@ -2,100 +2,114 @@
 
 <div id="select_view" class="row">
 
-<div class="button-group">
-<?php
+  <div class="button-group">
+    <?php
 
-// Show view selector (list, image-gallery, table and so on)
+    // Show view selector (list, image-gallery, table and so on)
 
-?>
-<?php
-		
-		//echo t('View').': ';
-		
-		if ($view == 'list') {
-			print '<a class="button secondary active" href="#">' . t('List') . '</a>';
-		} else {
-			if ($view == "preview") {
-				// if switching from preview mode to list, dont reset start to first result
-				// but on a regular page
-				$pagestart = floor($start / $limit) * limit;
-				$link = buildurl($params, "view", NULL, 's', $pagestart);
-			} else { // switching from other view like images or table, so reset start to first result
-				$link = buildurl($params, "view", NULL, 's', 1);
-			}
-			print '<a class="button secondary" onclick="waiting_on();" href="' . $link . '">' . t('List') . '</a>';
+    ?>
+    <?php
 
-		}
+    //echo t('View').': ';
 
-		if ($view == 'preview') {
-			print '<a class="button secondary active" href="#">'.t('Preview').'</a>';
-		} else {
-			print '<a class="button secondary" onclick="waiting_on();" href="' . buildurl($params, "view", 'preview') . '">' . t('Preview') . '</a>';
-		}
+    if ($view == 'list') {
+      print '<a class="button secondary active" href="#">' . t('List') . '</a>';
+    }
+    else {
+      if ($view == "preview") {
+        // if switching from preview mode to list, dont reset start to first result
+        // but on a regular page
+        $pagestart = floor($start / $limit) * limit;
+        $link = buildurl($params, "view", NULL, 's', $pagestart);
+      }
+      else { // switching from other view like images or table, so reset start to first result
+        $link = buildurl($params, "view", NULL, 's', 1);
+      }
+      print '<a class="button secondary" onclick="waiting_on();" href="' . $link . '">' . t('List') . '</a>';
 
-		if ($view == 'images') {
-			print '<a class="button secondary active" href="#">'.t('Images').'</a>';
-		} else {
-			print '<a class="button secondary" onclick="waiting_on();" href="' . buildurl($params, "view", 'images', 's', 1) . '">' . t('Images') . '</a>';
-		}
-		
-		if ($view == 'videos') {
-			print '<a class="button secondary active" href="#">'.t('Videos').'</a>';
-		} else {
-			print '<a class="button secondary" onclick="waiting_on();" href="' . buildurl($params, "view", 'videos', 's', 1) . '">' . t('Videos') . '</a>';
-		}
-		if ($view == 'audios') {
-			print '<a class="button secondary active" href="#">'.t('Audios').'</a>';
-		} else {
-			print '<a class="button secondary" onclick="waiting_on();" href="' . buildurl($params, "view", 'audios', 's', 1) . '">' . t('Audios') . '</a>';
-		}
-		
-		if ($view == 'table') {
-			print '<a class="button secondary active" href="#">'.t('Table').'</a>';
-		} else {
-			print '<a class="button secondary" onclick="waiting_on();" href="' . buildurl($params, "view", 'table', 's', 1) . '">' . t('Table') . '</a>';
-		}
+    }
 
-		if ($view=='trend') {
-			print '<a class="button secondary active" href="#">'.t('view_trend').'</a>';
-		} else {
-			print '<a class="button secondary" onclick="waiting_on();" href="'.buildurl($params,"view",'trend','s', false).'">'.t('view_trend').'</a>';
-		}
-				
-		
-		
-		?>
-		
-		<button class="button secondary dropdown" type="button" data-toggle="analyze-dropdown"><?php echo t("view_analytics"); ?></button>
+    if ($view == 'preview') {
+      print '<a class="button secondary active" href="#">' . t('Preview') . '</a>';
+    }
+    else {
+      print '<a class="button secondary" onclick="waiting_on();" href="' . buildurl($params, "view", 'preview') . '">' . t('Preview') . '</a>';
+    }
 
-		<div class="dropdown-pane" id="analyze-dropdown" data-dropdown data-auto-focus="true">
-				
-		<?php 
-		if ($view=='words') {
-			print '<a class="button active" href="#">'.t('view_words').'</a>';
-		} else {
-			print '<a class="button" onclick="waiting_on();" href="'.buildurl($params,"view",'words','s', false).'">'.t('view_words').'</a>';
-		}
-		?><hr/><?php
-				
-		if ($view == 'graph') {
-			print '<a class="button active" href="#">'.t('Named entities').'</a>';
-		} else {
-			print '<a class="button" onclick="waiting_on();" href="' . buildurl($params, "view", 'graph', 's', 1) . '">' . t('Named entities') . '</a>';
-		}
-		
-		?><hr/><?php
-				
-		if ($view=='graph') {
-			print '<a class="button active" href="#">'.t('Connections').'</a>';
-		} else {
-			print '<a class="button" onclick="waiting_on();" href="'.buildurl($params,"view",'graph','s', false).'">'.t('Connections').'</a>';
-		}
-		
-		
-?>
-</div>
+    if ($view == 'images') {
+      print '<a class="button secondary active" href="#">' . t('Images') . '</a>';
+    }
+    else {
+      print '<a class="button secondary" onclick="waiting_on();" href="' . buildurl($params, "view", 'images', 's', 1) . '">' . t('Images') . '</a>';
+    }
 
-</div>
+    if ($view == 'videos') {
+      print '<a class="button secondary active" href="#">' . t('Videos') . '</a>';
+    }
+    else {
+      print '<a class="button secondary" onclick="waiting_on();" href="' . buildurl($params, "view", 'videos', 's', 1) . '">' . t('Videos') . '</a>';
+    }
+    if ($view == 'audios') {
+      print '<a class="button secondary active" href="#">' . t('Audios') . '</a>';
+    }
+    else {
+      print '<a class="button secondary" onclick="waiting_on();" href="' . buildurl($params, "view", 'audios', 's', 1) . '">' . t('Audios') . '</a>';
+    }
+
+    if ($view == 'table') {
+      print '<a class="button secondary active" href="#">' . t('Table') . '</a>';
+    }
+    else {
+      print '<a class="button secondary" onclick="waiting_on();" href="' . buildurl($params, "view", 'table', 's', 1) . '">' . t('Table') . '</a>';
+    }
+
+    if ($view == 'trend') {
+      print '<a class="button secondary active" href="#">' . t('view_trend') . '</a>';
+    }
+    else {
+      print '<a class="button secondary" onclick="waiting_on();" href="' . buildurl($params, "view", 'trend', 's', FALSE) . '">' . t('view_trend') . '</a>';
+    }
+
+
+    ?>
+
+    <button class="button secondary dropdown" type="button"
+            data-toggle="analyze-dropdown"><?php echo t("view_analytics"); ?></button>
+
+    <div class="dropdown-pane" id="analyze-dropdown" data-dropdown
+         data-auto-focus="true">
+
+      <?php
+      if ($view == 'words') {
+        print '<a class="button active" href="#">' . t('view_words') . '</a>';
+      }
+      else {
+        print '<a class="button" onclick="waiting_on();" href="' . buildurl($params, "view", 'words', 's', FALSE) . '">' . t('view_words') . '</a>';
+      }
+      ?>
+      <hr/><?php
+
+      if ($view == 'graph') {
+        print '<a class="button active" href="#">' . t('Named entities') . '</a>';
+      }
+      else {
+        print '<a class="button" onclick="waiting_on();" href="' . buildurl($params, "view", 'graph', 's', 1) . '">' . t('Named entities') . '</a>';
+      }
+
+      ?>
+      <hr/><?php
+
+      if ($view == 'graph') {
+        print '<a class="button active" href="#">' . t('Connections') . '</a>';
+      }
+      else {
+        print '<a class="button" onclick="waiting_on();" href="' . buildurl($params, "view", 'graph', 's', FALSE) . '">' . t('Connections') . '</a>';
+      }
+
+
+      ?>
+    </div>
+
+  </div>
 
 </div>

--- a/src/templates/view.audios.php
+++ b/src/templates/view.audios.php
@@ -7,112 +7,119 @@
 
 <div id="results" class="row">
 
-<ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-2">
+  <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-2">
 
-<?php
-foreach ($results->response->docs as $doc) {
+    <?php
+    foreach ($results->response->docs as $doc) {
 
-  // URI
-  if (isset($doc->container_s)) {
-  	$id = $doc->container_s;
-  }
-  else {
-  	$id = $doc->id;
-  }
-  
-  
-  $uri_label = htmlspecialchars($id);
-  $uri_tip = false;
-  
-  // if file:// then only filename
-  if (strpos ($id, "file://")==0) {
-  	$uri_label = htmlspecialchars(basename($id));
-  	// for tooptip remove file:// from beginning
-  	$uri_tip = htmlspecialchars(substr( $id, 7 ));
-  }
-  
-  // Author
-  $author = htmlspecialchars($doc->author_s);
-
-  // Title
-  $title = false;
-  
-  if (isset($doc->title)) {
-    if (!empty($doc->title)) {
-    	$title= htmlspecialchars($doc->title);
-    }
-  }
-
-  // Type
-  $type= $doc->content_type;
-
-  // Modified date
-  if (isset($doc->file_modified_dt)) {
-	$datetime = $doc->file_modified_dt; 
-  } elseif (isset($doc->last_modified)) {
-  	$datetime = $doc->last_modified;
-  } else {
-  	$datetime=false;
-  }
+      // URI
+      if (isset($doc->container_s)) {
+        $id = $doc->container_s;
+      }
+      else {
+        $id = $doc->id;
+      }
 
 
-  // Snippet
-  if (isset($results->highlighting->$id->content)) {
-    $snippet = $results->highlighting->$id->content[0];
-  } else {
-	$snippet = $doc->content;
-	if (strlen($snippet) > $snippetsize) {
-		$snippet = substr($snippet,0,$snippetsize)."...";
-		$snippet = htmlspecialchars($snippet);
-	}
-  }
+      $uri_label = htmlspecialchars($id);
+      $uri_tip = FALSE;
 
-?>
-<li>
+      // if file:// then only filename
+      if (strpos($id, "file://") == 0) {
+        $uri_label = htmlspecialchars(basename($id));
+        // for tooptip remove file:// from beginning
+        $uri_tip = htmlspecialchars(substr($id, 7));
+      }
 
-	<div class="title">
-		<a class="title" target="_blank" href="<?=$id?>">
-				<?php if ($title) { ?>
-			<?=$title ?>
+      // Author
+      $author = htmlspecialchars($doc->author_s);
+
+      // Title
+      $title = FALSE;
+
+      if (isset($doc->title)) {
+        if (!empty($doc->title)) {
+          $title = htmlspecialchars($doc->title);
+        }
+      }
+
+      // Type
+      $type = $doc->content_type;
+
+      // Modified date
+      if (isset($doc->file_modified_dt)) {
+        $datetime = $doc->file_modified_dt;
+      }
+      elseif (isset($doc->last_modified)) {
+        $datetime = $doc->last_modified;
+      }
+      else {
+        $datetime = FALSE;
+      }
+
+
+      // Snippet
+      if (isset($results->highlighting->$id->content)) {
+        $snippet = $results->highlighting->$id->content[0];
+      }
+      else {
+        $snippet = $doc->content;
+        if (strlen($snippet) > $snippetsize) {
+          $snippet = substr($snippet, 0, $snippetsize) . "...";
+          $snippet = htmlspecialchars($snippet);
+        }
+      }
+
+      ?>
+      <li>
+
+        <div class="title">
+          <a class="title" target="_blank" href="<?= $id ?>">
+            <?php if ($title) { ?>
+              <?= $title ?>
+            <?php } ?>
+
+          </a>
+        </div>
+        <?php if ($uri_tip) { ?><span class="uri">
+					<span data-tooltip class="has-tip" title="<?= $uri_tip ?>">
 				<?php } ?>
-				
-		</a>
-	</div>
-						<?php if ($uri_tip) { ?><span class="uri">
-					<span data-tooltip class="has-tip" title="<?=$uri_tip?>">
-				<?php } ?>
-			<?=$uri_label?>
-				<?php if ($uri_tip) { ?>
+        <?= $uri_label ?>
+        <?php if ($uri_tip) { ?>
 					</span></span>
-				<?php } ?>
-	
+      <?php } ?>
 
-	
 
-	<div class="audio">
-			
-<audio controls="controls" preload="none" src="<?=$id?>"></audio>
+        <div class="audio">
 
-	</div>
-	
-	
-	<div class="row">
-		<div class="date small-8 columns"><?=$datetime?></div>
-		<div class="size small-4 columns"><?=$file_size_txt?></div>	
-	</div>
-	
-	<div class="snippet">
-		<?php if ($author) { print '<div class="author">'.$author.'</div>:'; } ?>
-<?=$snippet?>
-	</div>
-	<div class="commands">
-			<a target="_blank" href="<?=$id?>"><?php echo t('open'); ?></a> <?php if ($cfg['metadata']['server']) { ?> | <a target="_blank" title="<?php echo t('meta description'); ?>" href="<?php print get_metadata_uri ($cfg['metadata']['server'], $id); ?>"><?php echo t('meta'); ?></a> <?php } ?> | <?php print '<a target="_blank" href="preview.php?id='.urlencode($id).'">' . t('Preview') . '</a>'; ?>
-	</div>
-</li>
+          <audio controls="controls" preload="none" src="<?= $id ?>"></audio>
 
-<?php
-  } // foreach doc
-?>
+        </div>
 
-    </ul>
+
+        <div class="row">
+          <div class="date small-8 columns"><?= $datetime ?></div>
+          <div class="size small-4 columns"><?= $file_size_txt ?></div>
+        </div>
+
+        <div class="snippet">
+          <?php if ($author) {
+            print '<div class="author">' . $author . '</div>:';
+          } ?>
+          <?= $snippet ?>
+        </div>
+        <div class="commands">
+          <a target="_blank"
+             href="<?= $id ?>"><?php echo t('open'); ?></a> <?php if ($cfg['metadata']['server']) { ?> |
+            <a target="_blank" title="<?php echo t('meta description'); ?>"
+               href="<?php print get_metadata_uri($cfg['metadata']['server'], $id); ?>"><?php echo t('meta'); ?></a> <?php } ?>
+          | <?php print '<a target="_blank" href="preview.php?id=' . urlencode($id) . '">' . t('Preview') . '</a>'; ?>
+        </div>
+      </li>
+
+      <?php
+    } // foreach doc
+    ?>
+
+  </ul>
 </div>

--- a/src/templates/view.embedded.php
+++ b/src/templates/view.embedded.php
@@ -1,67 +1,75 @@
-	<?php 
-	
-	// if no results, show message
-	if ($total == 0) {
-		?>
-	<div id="noresults" class="panel">
+<?php
+
+// if no results, show message
+if ($total == 0) {
+  ?>
+  <div id="noresults" class="panel">
 
 
-		<?php
-		if ($error) {
-			print '<p>Error: </p><p>' . $error . '</p>';
-		} else {
-			// Todo: Vorschlag: (in allen Bereichen, Ähnliches)
-			print t('No results');
-		}
-		?>
-	</div>
+    <?php
+    if ($error) {
+      print '<p>Error: </p><p>' . $error . '</p>';
+    }
+    else {
+      // Todo: Vorschlag: (in allen Bereichen, Ähnliches)
+      print t('No results');
+    }
+    ?>
+  </div>
 
-	<?php
-	} // total == 0
-	else { // there are results documents
-		
-		if ($error) {
-			print '<p>Error:</p><p>' . $error . '</p>';
-		}
-		
-		// print the results with selected view template
-		if ($view == 'list') {
-			include 'templates/pagination.php';
-			include 'templates/view.list.php';
-			include 'templates/pagination.php';
-				
-		} elseif ($view == 'preview') {
+  <?php
+} // total == 0
+else { // there are results documents
 
-			include 'templates/view.preview.php';
+  if ($error) {
+    print '<p>Error:</p><p>' . $error . '</p>';
+  }
 
-		} elseif ($view == 'images') {
-				
-			include 'templates/view.images.php';
+  // print the results with selected view template
+  if ($view == 'list') {
+    include 'templates/pagination.php';
+    include 'templates/view.list.php';
+    include 'templates/pagination.php';
 
-		} elseif ($view == 'videos') {
-			include 'templates/view.videos.php';
-		} elseif ($view == 'table') {
-			include 'templates/view.table.php';
-		} elseif ($view=='words') {
+  }
+  elseif ($view == 'preview') {
 
-			include 'templates/view.words.php';
+    include 'templates/view.preview.php';
 
-		} elseif ($view=='trend') {
+  }
+  elseif ($view == 'images') {
 
-			include 'templates/view.trend.php';
+    include 'templates/view.images.php';
 
-		} elseif ($view == 'timeline') {
+  }
+  elseif ($view == 'videos') {
+    include 'templates/view.videos.php';
+  }
+  elseif ($view == 'table') {
+    include 'templates/view.table.php';
+  }
+  elseif ($view == 'words') {
 
-			include 'timeline.php';
+    include 'templates/view.words.php';
 
-		}
-		else {
-			include 'templates/pagination.php';
-			include 'templates/view.list.php';
-			include 'templates/pagination.php';
-				
-		}
+  }
+  elseif ($view == 'trend') {
+
+    include 'templates/view.trend.php';
+
+  }
+  elseif ($view == 'timeline') {
+
+    include 'timeline.php';
+
+  }
+  else {
+    include 'templates/pagination.php';
+    include 'templates/view.list.php';
+    include 'templates/pagination.php';
+
+  }
 
 
-	} // if total <> 0: there were documents
-	?>
+} // if total <> 0: there were documents
+?>

--- a/src/templates/view.facets.php
+++ b/src/templates/view.facets.php
@@ -1,169 +1,174 @@
 <div id="facets">
-			<?php
+  <?php
 
-			// todo: hover durchgestrichen bei (x)-Werten
+  // todo: hover durchgestrichen bei (x)-Werten
 
-			// if active facets, show them and possibility to unlink
-			if ($selected_facets or $not_content_types or $deselected_facets or $deselected_paths or $types or $typegroups) {
-				?>
-			<div id="filter" class="facet">
-				<h2 title="<?php echo t('Filter criterias');?>">
-					<?php echo t("Selected filters"); ?>
-				</h2>
-				<ul id="selected" class="no-bullet">
-					<?php
+  // if active facets, show them and possibility to unlink
+  if ($selected_facets or $not_content_types or $deselected_facets or $deselected_paths or $types or $typegroups) {
+    ?>
+    <div id="filter" class="facet">
+      <h2 title="<?php echo t('Filter criterias'); ?>">
+        <?php echo t("Selected filters"); ?>
+      </h2>
+      <ul id="selected" class="no-bullet">
+        <?php
 
-					foreach ($deselected_paths as $deselected_path) {
-						print '<li><a onclick="waiting_on();" title="'.t('Remove filter').'" href="'.buildurl_delvalue($params, 'NOT_path', $deselected_path, 's',1).'">(&times;)</a> NOT in '.htmlspecialchars($deselected_path).'</li>';
-					}
+        foreach ($deselected_paths as $deselected_path) {
+          print '<li><a onclick="waiting_on();" title="' . t('Remove filter') . '" href="' . buildurl_delvalue($params, 'NOT_path', $deselected_path, 's', 1) . '">(&times;)</a> NOT in ' . htmlspecialchars($deselected_path) . '</li>';
+        }
 
-						
-					
-					foreach ($selected_facets as $selected_facet => $facetvalue_array) {
-						foreach ($facetvalue_array as $facet_value) {
-							print '<li><a onclick="waiting_on();" title="'.t('Remove filter').'" href="'.buildurl_delvalue($params, $selected_facet, $facet_value, 's',1).'">(&times;)</a> '.$cfg[facets][$selected_facet]['label'].': '.htmlspecialchars($facet_value).'</li>';
-						}
-					}
 
-					foreach ($deselected_facets as $deselected_facet => $facetvalue_array) {
-						foreach ($facetvalue_array as $facet_value) {
-							print '<li><a onclick="waiting_on();" title="'.t('Remove filter').'" href="'.buildurl_delvalue($params, 'NOT_'.$deselected_facet, $facet_value, 's',1).'">(&times;)</a> NOT '.$cfg[facets][$deselected_facet]['label'].': '.htmlspecialchars($facet_value).'</li>';
-						}
-					}
-						
+        foreach ($selected_facets as $selected_facet => $facetvalue_array) {
+          foreach ($facetvalue_array as $facet_value) {
+            print '<li><a onclick="waiting_on();" title="' . t('Remove filter') . '" href="' . buildurl_delvalue($params, $selected_facet, $facet_value, 's', 1) . '">(&times;)</a> ' . $cfg[facets][$selected_facet]['label'] . ': ' . htmlspecialchars($facet_value) . '</li>';
+          }
+        }
 
-					foreach ($types as $type) {
-						print '<li><a onclick="waiting_on();" title="'.t('Remove filter').'" href="'.buildurl($params, 'type', false,'s',1).'">(&times;)</a> Typ: '.htmlspecialchars($type).'</li>';
-					}
+        foreach ($deselected_facets as $deselected_facet => $facetvalue_array) {
+          foreach ($facetvalue_array as $facet_value) {
+            print '<li><a onclick="waiting_on();" title="' . t('Remove filter') . '" href="' . buildurl_delvalue($params, 'NOT_' . $deselected_facet, $facet_value, 's', 1) . '">(&times;)</a> NOT ' . $cfg[facets][$deselected_facet]['label'] . ': ' . htmlspecialchars($facet_value) . '</li>';
+          }
+        }
 
-					foreach ($not_content_types as $not_content_type) {
-						print '<li><a onclick="waiting_on();" title="'.t('Remove filter').'" href="'.buildurl_delvalue($params, 'NOT_content_type', $not_content_type, 's',1).'">(&times;)</a> NOT '.htmlspecialchars($not_content_type).'</li>';
-					}
-						
-					
-					foreach ($typegroups as $typegroup) {
-						print '<li><a onclick="waiting_on();" title="'.t('Remove filter').'" href="'.buildurl($params, 'typegroup', false,'s',1).'">(&times;)</a> Form: '.htmlspecialchars($mimetypes[$typegroup]['name']).'</li>';
-					}
-					?>
-				</ul>
-			</div>
-			<?php
-			}
-			?>
 
-			<?php
-			if ($path) {
-				?>
-			<div id="path">
-				<h2>
-					<?php echo t('Path'); ?>
-				</h2>
+        foreach ($types as $type) {
+          print '<li><a onclick="waiting_on();" title="' . t('Remove filter') . '" href="' . buildurl($params, 'type', FALSE, 's', 1) . '">(&times;)</a> Typ: ' . htmlspecialchars($type) . '</li>';
+        }
 
-				<?php
-				$trimmedpath = trim($path, '/');
+        foreach ($not_content_types as $not_content_type) {
+          print '<li><a onclick="waiting_on();" title="' . t('Remove filter') . '" href="' . buildurl_delvalue($params, 'NOT_content_type', $not_content_type, 's', 1) . '">(&times;)</a> NOT ' . htmlspecialchars($not_content_type) . '</li>';
+        }
 
-				$paths = explode('/', $trimmedpath);
 
-				print '<ul><li><a onclick="waiting_on();" href="' . buildurl($params, "path", '', 's', 1) . '">'.t("All paths").'</a>';
+        foreach ($typegroups as $typegroup) {
+          print '<li><a onclick="waiting_on();" title="' . t('Remove filter') . '" href="' . buildurl($params, 'typegroup', FALSE, 's', 1) . '">(&times;)</a> Form: ' . htmlspecialchars($mimetypes[$typegroup]['name']) . '</li>';
+        }
+        ?>
+      </ul>
+    </div>
+    <?php
+  }
+  ?>
 
-			    $fullpath = '';
-    			for ($i = 0; $i < count($paths) - 1; $i++) {
-			    	$fullpath .= '/' . $paths[$i];
-      				echo '<ul><li><a onclick="waiting_on();" href="' . buildurl($params, "path", $fullpath, 's', 1) . '">' . $paths[$i] . '</a>' . "\n";
-    			}
-				
-				echo '<ul><li><b>' . htmlspecialchars($paths[count($paths) - 1]) . '</b></li></ul>';
+  <?php
+  if ($path) {
+    ?>
+    <div id="path">
+      <h2>
+        <?php echo t('Path'); ?>
+      </h2>
 
-				for ($i = 0; $i < count($paths) - 1; $i++) {
-					echo '</li></ul>' . "\n";
-				}
+      <?php
+      $trimmedpath = trim($path, '/');
 
-				?>
-			</div>
-			<?php
-			} // if path
-			?>
+      $paths = explode('/', $trimmedpath);
 
-			<?php
+      print '<ul><li><a onclick="waiting_on();" href="' . buildurl($params, "path", '', 's', 1) . '">' . t("All paths") . '</a>';
 
-				if (isset($results->facet_counts->facet_fields->$pathfacet)) {
-					if ($cfg['debug']) {
-						print 'path: ' . $path;
-						print 'pathfacet: ' . $pathfacet . '<br>';
-						print_r($results->facet_counts->facet_fields->$pathfacet);
-					}
-					?>
+      $fullpath = '';
+      for ($i = 0; $i < count($paths) - 1; $i++) {
+        $fullpath .= '/' . $paths[$i];
+        echo '<ul><li><a onclick="waiting_on();" href="' . buildurl($params, "path", $fullpath, 's', 1) . '">' . $paths[$i] . '</a>' . "\n";
+      }
 
-			<div id="sub" class="facet">
-				<h2>
-					<?php if ($path) print t('Subpaths'); else print t('Paths'); ?>
-				</h2><ul class="no-bullet">
-				<?php
-				foreach ($results->facet_counts->facet_fields->$pathfacet as $subpath => $count) {
+      echo '<ul><li><b>' . htmlspecialchars($paths[count($paths) - 1]) . '</b></li></ul>';
 
-					$fullpath = $path . '/' . $subpath;
+      for ($i = 0; $i < count($paths) - 1; $i++) {
+        echo '</li></ul>' . "\n";
+      }
 
-					print '<li><a onclick="waiting_on();" href="' . buildurl($params, "path", $fullpath, 's', 1) . '">' . htmlspecialchars($subpath) . '</a> (' . $count . ') <a onclick="waiting_on();" href="' . buildurl_addvalue($params, "NOT_path", $fullpath, 's', 1) . '">-</a></li>';
-				}
-				?>
-				</ul>
-			</div>
+      ?>
+    </div>
+    <?php
+  } // if path
+  ?>
 
-			<?php
-				} // if subpaths
+  <?php
 
-				
-				
-				
-				?>
-				
-				<div id="file_modified_dt" class="facet">
-				<h2>
-					<?php echo t('File date');  ?>
-				</h2>
-				
-				<?php // navigation up
-				
-				if ($upzoom_link) {
-					print '<a onclick="waiting_on();" href="' . $upzoom_link . '">' . $upzoom_label . '</a> &gt; ' . $date_label;
-				}
-				 
-				?>
-				<ul class="no-bullet">
-				
-				<?php
+  if (isset($results->facet_counts->facet_fields->$pathfacet)) {
+    if ($cfg['debug']) {
+      print 'path: ' . $path;
+      print 'pathfacet: ' . $pathfacet . '<br>';
+      print_r($results->facet_counts->facet_fields->$pathfacet);
+    }
+    ?>
 
-				// newest first
-				if ($zoom='years') {
-					$datevaluessorted = array_reverse($datevalues);
-				} else { $datavaluessorted = $datavalues; }
-				
-				foreach ($datevaluessorted as $value) {
+    <div id="sub" class="facet">
+      <h2>
+        <?php if ($path) {
+          print t('Subpaths');
+        } else {
+          print t('Paths');
+        } ?>
+      </h2>
+      <ul class="no-bullet">
+        <?php
+        foreach ($results->facet_counts->facet_fields->$pathfacet as $subpath => $count) {
 
-					if ($value['count'] > 0) {
-						print '<li><a onclick="waiting_on();" href="'.$value['link'].'">'.$value['label'].'</a> ('.$value['count'].')</li>';
-					}
-				}
-				
-					
-				?>
-				    </ul>
-				    
-				</div>
-				
-				<?php 
-				
+          $fullpath = $path . '/' . $subpath;
 
-				// Print all configurated facets
-				foreach ($cfg['facets'] as $facet => $facet_config) {
+          print '<li><a onclick="waiting_on();" href="' . buildurl($params, "path", $fullpath, 's', 1) . '">' . htmlspecialchars($subpath) . '</a> (' . $count . ') <a onclick="waiting_on();" href="' . buildurl_addvalue($params, "NOT_path", $fullpath, 's', 1) . '">-</a></li>';
+        }
+        ?>
+      </ul>
+    </div>
 
-					if ($cfg['debug']) {
-						print ($facet) . '<br />';
-						print_r($facet_config);
-					}
+    <?php
+  } // if subpaths
 
-					print_facet($results, $facet, t($facet_config['label']), $facets_limit );
-				}
-?>
+
+  ?>
+
+  <div id="file_modified_dt" class="facet">
+    <h2>
+      <?php echo t('File date'); ?>
+    </h2>
+
+    <?php // navigation up
+
+    if ($upzoom_link) {
+      print '<a onclick="waiting_on();" href="' . $upzoom_link . '">' . $upzoom_label . '</a> &gt; ' . $date_label;
+    }
+
+    ?>
+    <ul class="no-bullet">
+
+      <?php
+
+      // newest first
+      if ($zoom = 'years') {
+        $datevaluessorted = array_reverse($datevalues);
+      }
+      else {
+        $datavaluessorted = $datavalues;
+      }
+
+      foreach ($datevaluessorted as $value) {
+
+        if ($value['count'] > 0) {
+          print '<li><a onclick="waiting_on();" href="' . $value['link'] . '">' . $value['label'] . '</a> (' . $value['count'] . ')</li>';
+        }
+      }
+
+
+      ?>
+    </ul>
+
+  </div>
+
+  <?php
+
+
+  // Print all configurated facets
+  foreach ($cfg['facets'] as $facet => $facet_config) {
+
+    if ($cfg['debug']) {
+      print ($facet) . '<br />';
+      print_r($facet_config);
+    }
+
+    print_facet($results, $facet, t($facet_config['label']), $facets_limit);
+  }
+  ?>
 
 </div>

--- a/src/templates/view.facets.php
+++ b/src/templates/view.facets.php
@@ -97,7 +97,8 @@
       <h2>
         <?php if ($path) {
           print t('Subpaths');
-        } else {
+        }
+        else {
           print t('Paths');
         } ?>
       </h2>

--- a/src/templates/view.graph.php
+++ b/src/templates/view.graph.php
@@ -5,408 +5,423 @@
 
 <script type="text/javascript">
 
-<?php 
+  <?php
 
-function getedges($cfg, $solr, $solrquery, $additionalParameters, $facet_field, $entity) {
+  function getedges($cfg, $solr, $solrquery, $additionalParameters, $facet_field, $entity) {
 
-	$edges = array();
-	
-	$solrfacet = addcslashes($facet_field, '+-&|!(){}[]^"~*?:\/ ');
-	$solrfacetvalue = addcslashes($entity, '+-&|!(){}[]^"~*?:\/ ');
+    $edges = array();
 
-	
-	$mysolrquery = $solrfacet . ':' . $solrfacetvalue;
-	// not needed anymore, since we set the (not changing) $solrquery as more performant because cachable filter query
-	//$mysolrquery = $solrquery . ' AND ' . $solrfacet . ':' . $solrfacetvalue;
-	
-	$tempresults = $solr->search($mysolrquery, 0, 0, $additionalParameters);
+    $solrfacet = addcslashes($facet_field, '+-&|!(){}[]^"~*?:\/ ');
+    $solrfacetvalue = addcslashes($entity, '+-&|!(){}[]^"~*?:\/ ');
 
 
-	foreach ($cfg['facets'] as $facet_field => $facet_config) {
+    $mysolrquery = $solrfacet . ':' . $solrfacetvalue;
+    // not needed anymore, since we set the (not changing) $solrquery as more performant because cachable filter query
+    //$mysolrquery = $solrquery . ' AND ' . $solrfacet . ':' . $solrfacetvalue;
 
-		#print "checking ".$facet_field;
-		
-		if (isset($tempresults->facet_counts->facet_fields->$facet_field)) {
-			if (count(get_object_vars($tempresults->facet_counts->facet_fields->$facet_field)) > 0) {
-	
-				foreach ($tempresults->facet_counts->facet_fields->$facet_field as $facet => $count) {
-					#$facet_field, $facet $facet $count ;
-					if ($entity != $facet) {
-						$edges[]= array("source"=> $entity, "target"=> $facet, "weight" => $count);
-					}
-				}
-			}
-		} // if isset facetfield
-	
-	}
-	
-	
-	
-	return $edges;
-
-}
+    $tempresults = $solr->search($mysolrquery, 0, 0, $additionalParameters);
 
 
-$elements=array();
-$edges = array();
-$weight = array();
+    foreach ($cfg['facets'] as $facet_field => $facet_config) {
 
-# since we will do many queries for each facet value set the not changing part from former solr query/search context to performant because cached filter query
-$additionalParameters['fq'] = $solrquery;
+      #print "checking ".$facet_field;
 
+      if (isset($tempresults->facet_counts->facet_fields->$facet_field)) {
+        if (count(get_object_vars($tempresults->facet_counts->facet_fields->$facet_field)) > 0) {
 
-foreach ($cfg['facets'] as $facet_field => $facet_config) {
+          foreach ($tempresults->facet_counts->facet_fields->$facet_field as $facet => $count) {
+            #$facet_field, $facet $facet $count ;
+            if ($entity != $facet) {
+              $edges[] = array(
+                "source" => $entity,
+                "target" => $facet,
+                "weight" => $count
+              );
+            }
+          }
+        }
+      } // if isset facetfield
 
-	if (isset($results->facet_counts->facet_fields->$facet_field)) {
-		if (count(get_object_vars($results->facet_counts->facet_fields->$facet_field)) > 0) {
-		
-			foreach ($results->facet_counts->facet_fields->$facet_field as $facet => $count) {
-				#$facet_field, $facet $count ;
-				$entity = $facet;
-				//$elements[] = $entity;
-
-				// todo: scale from min (1 px) to max (max configurable)
-				$weight[$entity]=bcsqrt($count,0)*10;
-				
-				$myedges=getedges($cfg, $solr, $solrquery, $additionalParameters, $facet_field, $entity);
-			 	$edges = array_merge($edges, $myedges);
-			}
-		}
-	} // if isset facetfield
-	
-}
-
-foreach ($edges as $edge) {
-	if (in_array($edge["source"], $elements)==false) {
-		$elements[] = $edge["source"];
-	}
-}
+    }
 
 
-?>
+    return $edges;
+
+  }
 
 
+  $elements = array();
+  $edges = array();
+  $weight = array();
+
+  # since we will do many queries for each facet value set the not changing part from former solr query/search context to performant because cached filter query
+  $additionalParameters['fq'] = $solrquery;
 
 
-var elements = {
-	      nodes: [
-	
-<?php
+  foreach ($cfg['facets'] as $facet_field => $facet_config) {
 
-	$first = true;
-	foreach ($elements as $element) {
+    if (isset($results->facet_counts->facet_fields->$facet_field)) {
+      if (count(get_object_vars($results->facet_counts->facet_fields->$facet_field)) > 0) {
 
-		// if not first entry, print delimiting comma
-		if ($first) { $first = false; } else {print ",\n"; }
-		
-		print "{data:{id:'".str_replace("'", "", $element)."', weight: ".$weight[$element]."}}";
- 		 
+        foreach ($results->facet_counts->facet_fields->$facet_field as $facet => $count) {
+          #$facet_field, $facet $count ;
+          $entity = $facet;
+          //$elements[] = $entity;
 
-	}
-?>
-	      ], 
+          // todo: scale from min (1 px) to max (max configurable)
+          $weight[$entity] = bcsqrt($count, 0) * 10;
 
-	      
-	  	      edges: [
+          $myedges = getedges($cfg, $solr, $solrquery, $additionalParameters, $facet_field, $entity);
+          $edges = array_merge($edges, $myedges);
+        }
+      }
+    } // if isset facetfield
 
-	  	          <?php 
-	  	          	$first = true;
-					$i = 0;
-	  	        	foreach ($edges as $edge) {
-	  	        		$i++;
+  }
 
-	  	        		// if not first entry, print delimiting comma
-		  	      		if ($first) { $first = false; } else {print ",\n"; }
-	  	      		
-		  	      		print "{data:{id: 'edge".$i."',source:'".str_replace("'", "", $edge["source"])."', target:'".str_replace("'", "", $edge["target"])."', weight: ".$edge["weight"]." }}";
+  foreach ($edges as $edge) {
+    if (in_array($edge["source"], $elements) == FALSE) {
+      $elements[] = $edge["source"];
+    }
+  }
 
 
-	  	      	}
-	  	      	?>
-	  	      		  	      	
-	  	        ]
-	  	    }
-
-
-function subnav_deactivate_active(){
-	document.getElementById('sub_nav_cose').className = "tabs-title";
-	document.getElementById('sub_nav_circle').className = "tabs-title";
-	document.getElementById('sub_nav_concentric').className = "tabs-title";
-	document.getElementById('sub_nav_grid').className = "tabs-title";
-	document.getElementById('sub_nav_breadthfirst').className = "tabs-title";
-}
-
-
-function view_cose(){
-
-	 subnav_deactivate_active();
-	 
-	 document.getElementById("sub_nav_cose").className = "tabs-title is-active";
-
-	var cy = cytoscape({
-		  container: document.getElementById('cy'),
-		  
-		  style: cytoscape.stylesheet()
-		    .selector('node')
-		      .css({
-		        'content': 'data(id)',
-			    'width': 'data(weight)',
-				'height': 'data(weight)'
-			    
-		      })
-		    .selector('edge')
-		      .css({
-		        'target-arrow-shape': 'triangle',
-		        'width': 'data(weight)',
-		        'line-color': '#ddd',
-		        'target-arrow-color': '#ddd'
-		      })
-		    .selector('.highlighted')
-		      .css({
-		        'background-color': '#61bffc',
-		        'line-color': '#61bffc',
-		        'target-arrow-color': '#61bffc',
-		        'transition-property': 'background-color, line-color, target-arrow-color',
-		        'transition-duration': '0.5s'
-		      }),
-		  
-		  elements: elements,
-		  
-		  
-
-		  layout: {
-			    name: 'cose'
-			  }
-		  
-		});
- 
-}
-	  	    
-function view_circle(){
-
-	 subnav_deactivate_active();
-	 
-	 document.getElementById("sub_nav_circle").className = "tabs-title is-active";
-	
-	var cy = cytoscape({
-		  container: document.getElementById('cy'),
-		  
-		  style: cytoscape.stylesheet()
-		    .selector('node')
-		      .css({
-		        'content': 'data(id)',
-			    'width': 'data(weight)',
-				'height': 'data(weight)'
-			    
-		      })
-		    .selector('edge')
-		      .css({
-		        'target-arrow-shape': 'triangle',
-		        'width': 'data(weight)',
-		        'line-color': '#ddd',
-		        'target-arrow-color': '#ddd'
-		      })
-		    .selector('.highlighted')
-		      .css({
-		        'background-color': '#61bffc',
-		        'line-color': '#61bffc',
-		        'target-arrow-color': '#61bffc',
-		        'transition-property': 'background-color, line-color, target-arrow-color',
-		        'transition-duration': '0.5s'
-		      }),
-		  
-		  elements: elements,
-		  
-		  
-
-		  layout: {
-			    name: 'circle'
-			  }
-		  
-		});
-		
-}
-
-function view_concentric(){
-
-	 subnav_deactivate_active();
-	 
-	 document.getElementById("sub_nav_concentric").className = "tabs-title is-active";
-	
-	var cy = cytoscape({
-		  container: document.getElementById('cy'),
-		  
-		  style: cytoscape.stylesheet()
-		    .selector('node')
-		      .css({
-		        'content': 'data(id)',
-			    'width': 'data(weight)',
-				'height': 'data(weight)'
-			    
-		      })
-		    .selector('edge')
-		      .css({
-		        'target-arrow-shape': 'triangle',
-		        'width': 'data(weight)',
-		        'line-color': '#ddd',
-		        'target-arrow-color': '#ddd'
-		      })
-		    .selector('.highlighted')
-		      .css({
-		        'background-color': '#61bffc',
-		        'line-color': '#61bffc',
-		        'target-arrow-color': '#61bffc',
-		        'transition-property': 'background-color, line-color, target-arrow-color',
-		        'transition-duration': '0.5s'
-		      }),
-		  
-		  elements: elements,
-		  
-		  
-
-		  layout: {
-			    name: 'concentric'
-			  }
-		  
-		});
-		
-}
-
-function view_grid(){
-
-	 subnav_deactivate_active();
-	 
-	 document.getElementById("sub_nav_grid").className = "tabs-title is-active";
-
-	var cy = cytoscape({
-		  container: document.getElementById('cy'),
-		  
-		  style: cytoscape.stylesheet()
-		    .selector('node')
-		      .css({
-		        'content': 'data(id)',
-			    'width': 'data(weight)',
-				'height': 'data(weight)'
-			    
-		      })
-		    .selector('edge')
-		      .css({
-		        'target-arrow-shape': 'triangle',
-		        'width': 'data(weight)',
-		        'line-color': '#ddd',
-		        'target-arrow-color': '#ddd'
-		      })
-		    .selector('.highlighted')
-		      .css({
-		        'background-color': '#61bffc',
-		        'line-color': '#61bffc',
-		        'target-arrow-color': '#61bffc',
-		        'transition-property': 'background-color, line-color, target-arrow-color',
-		        'transition-duration': '0.5s'
-		      }),
-		  
-		  elements: elements,
-		  
-		  
-
-		  layout: {
-			    name: 'grid'
-			  }
-		  
-		});
-
-}
-
-function view_breadthfirst(){
-
-	 subnav_deactivate_active();
-	 
-	 document.getElementById("sub_nav_breadthfirst").className = "tabs-title is-active";
-
-	var cy = cytoscape({
-		  container: document.getElementById('cy'),
-		  
-		  style: cytoscape.stylesheet()
-		    .selector('node')
-		      .css({
-		        'content': 'data(id)',
-			    'width': 'data(weight)',
-				'height': 'data(weight)'
-			    
-		      })
-		    .selector('edge')
-		      .css({
-		        'target-arrow-shape': 'triangle',
-		        'width': 'data(weight)',
-		        'line-color': '#ddd',
-		        'target-arrow-color': '#ddd'
-		      })
-		    .selector('.highlighted')
-		      .css({
-		        'background-color': '#61bffc',
-		        'line-color': '#61bffc',
-		        'target-arrow-color': '#61bffc',
-		        'transition-property': 'background-color, line-color, target-arrow-color',
-		        'transition-duration': '0.5s'
-		      }),
-		  
-		  elements: elements,
-		  
-		  
-
-		  layout: {
-			    name: 'breadthfirst'
-			  }
-		  
-		});
-
-	var options = {
-			  name: 'breadthfirst',
-
-			  fit: true, // whether to fit the viewport to the graph
-			  directed: false, // whether the tree is directed downwards (or edges can point in any direction if false)
-			  padding: 30, // padding on fit
-			  circle: false, // put depths in concentric circles if true, put depths top down if false
-			  spacingFactor: 1.75, // positive spacing factor, larger => more space between nodes (N.B. n/a if causes overlap)
-			  boundingBox: undefined, // constrain layout bounds; { x1, y1, x2, y2 } or { x1, y1, w, h }
-			  avoidOverlap: true, // prevents node overlap, may overflow boundingBox if not enough space
-			  roots: undefined, // the roots of the trees
-			  maximalAdjustments: 0, // how many times to try to position the nodes in a maximal way (i.e. no backtracking)
-			  animate: false, // whether to transition the node positions
-			  animationDuration: 500, // duration of animation in ms if enabled
-			  ready: undefined, // callback on layoutready
-			  stop: undefined // callback on layoutstop
-			};
-
-			cy.layout( options );
-}
+  ?>
 
 
 
-$(function(){ // on dom ready
 
-	view_cose();
+  var elements = {
+    nodes: [
 
-}); // on dom ready
+      <?php
+
+      $first = TRUE;
+      foreach ($elements as $element) {
+
+        // if not first entry, print delimiting comma
+        if ($first) {
+          $first = FALSE;
+        }
+        else {
+          print ",\n";
+        }
+
+        print "{data:{id:'" . str_replace("'", "", $element) . "', weight: " . $weight[$element] . "}}";
+
+
+      }
+      ?>
+    ],
+
+
+    edges: [
+
+      <?php
+      $first = TRUE;
+      $i = 0;
+      foreach ($edges as $edge) {
+        $i++;
+
+        // if not first entry, print delimiting comma
+        if ($first) {
+          $first = FALSE;
+        }
+        else {
+          print ",\n";
+        }
+
+        print "{data:{id: 'edge" . $i . "',source:'" . str_replace("'", "", $edge["source"]) . "', target:'" . str_replace("'", "", $edge["target"]) . "', weight: " . $edge["weight"] . " }}";
+
+
+      }
+      ?>
+
+    ]
+  }
+
+
+  function subnav_deactivate_active() {
+    document.getElementById('sub_nav_cose').className = "tabs-title";
+    document.getElementById('sub_nav_circle').className = "tabs-title";
+    document.getElementById('sub_nav_concentric').className = "tabs-title";
+    document.getElementById('sub_nav_grid').className = "tabs-title";
+    document.getElementById('sub_nav_breadthfirst').className = "tabs-title";
+  }
+
+
+  function view_cose() {
+
+    subnav_deactivate_active();
+
+    document.getElementById("sub_nav_cose").className = "tabs-title is-active";
+
+    var cy = cytoscape({
+      container: document.getElementById('cy'),
+
+      style: cytoscape.stylesheet()
+        .selector('node')
+        .css({
+          'content': 'data(id)',
+          'width': 'data(weight)',
+          'height': 'data(weight)'
+
+        })
+        .selector('edge')
+        .css({
+          'target-arrow-shape': 'triangle',
+          'width': 'data(weight)',
+          'line-color': '#ddd',
+          'target-arrow-color': '#ddd'
+        })
+        .selector('.highlighted')
+        .css({
+          'background-color': '#61bffc',
+          'line-color': '#61bffc',
+          'target-arrow-color': '#61bffc',
+          'transition-property': 'background-color, line-color, target-arrow-color',
+          'transition-duration': '0.5s'
+        }),
+
+      elements: elements,
+
+
+      layout: {
+        name: 'cose'
+      }
+
+    });
+
+  }
+
+  function view_circle() {
+
+    subnav_deactivate_active();
+
+    document.getElementById("sub_nav_circle").className = "tabs-title is-active";
+
+    var cy = cytoscape({
+      container: document.getElementById('cy'),
+
+      style: cytoscape.stylesheet()
+        .selector('node')
+        .css({
+          'content': 'data(id)',
+          'width': 'data(weight)',
+          'height': 'data(weight)'
+
+        })
+        .selector('edge')
+        .css({
+          'target-arrow-shape': 'triangle',
+          'width': 'data(weight)',
+          'line-color': '#ddd',
+          'target-arrow-color': '#ddd'
+        })
+        .selector('.highlighted')
+        .css({
+          'background-color': '#61bffc',
+          'line-color': '#61bffc',
+          'target-arrow-color': '#61bffc',
+          'transition-property': 'background-color, line-color, target-arrow-color',
+          'transition-duration': '0.5s'
+        }),
+
+      elements: elements,
+
+
+      layout: {
+        name: 'circle'
+      }
+
+    });
+
+  }
+
+  function view_concentric() {
+
+    subnav_deactivate_active();
+
+    document.getElementById("sub_nav_concentric").className = "tabs-title is-active";
+
+    var cy = cytoscape({
+      container: document.getElementById('cy'),
+
+      style: cytoscape.stylesheet()
+        .selector('node')
+        .css({
+          'content': 'data(id)',
+          'width': 'data(weight)',
+          'height': 'data(weight)'
+
+        })
+        .selector('edge')
+        .css({
+          'target-arrow-shape': 'triangle',
+          'width': 'data(weight)',
+          'line-color': '#ddd',
+          'target-arrow-color': '#ddd'
+        })
+        .selector('.highlighted')
+        .css({
+          'background-color': '#61bffc',
+          'line-color': '#61bffc',
+          'target-arrow-color': '#61bffc',
+          'transition-property': 'background-color, line-color, target-arrow-color',
+          'transition-duration': '0.5s'
+        }),
+
+      elements: elements,
+
+
+      layout: {
+        name: 'concentric'
+      }
+
+    });
+
+  }
+
+  function view_grid() {
+
+    subnav_deactivate_active();
+
+    document.getElementById("sub_nav_grid").className = "tabs-title is-active";
+
+    var cy = cytoscape({
+      container: document.getElementById('cy'),
+
+      style: cytoscape.stylesheet()
+        .selector('node')
+        .css({
+          'content': 'data(id)',
+          'width': 'data(weight)',
+          'height': 'data(weight)'
+
+        })
+        .selector('edge')
+        .css({
+          'target-arrow-shape': 'triangle',
+          'width': 'data(weight)',
+          'line-color': '#ddd',
+          'target-arrow-color': '#ddd'
+        })
+        .selector('.highlighted')
+        .css({
+          'background-color': '#61bffc',
+          'line-color': '#61bffc',
+          'target-arrow-color': '#61bffc',
+          'transition-property': 'background-color, line-color, target-arrow-color',
+          'transition-duration': '0.5s'
+        }),
+
+      elements: elements,
+
+
+      layout: {
+        name: 'grid'
+      }
+
+    });
+
+  }
+
+  function view_breadthfirst() {
+
+    subnav_deactivate_active();
+
+    document.getElementById("sub_nav_breadthfirst").className = "tabs-title is-active";
+
+    var cy = cytoscape({
+      container: document.getElementById('cy'),
+
+      style: cytoscape.stylesheet()
+        .selector('node')
+        .css({
+          'content': 'data(id)',
+          'width': 'data(weight)',
+          'height': 'data(weight)'
+
+        })
+        .selector('edge')
+        .css({
+          'target-arrow-shape': 'triangle',
+          'width': 'data(weight)',
+          'line-color': '#ddd',
+          'target-arrow-color': '#ddd'
+        })
+        .selector('.highlighted')
+        .css({
+          'background-color': '#61bffc',
+          'line-color': '#61bffc',
+          'target-arrow-color': '#61bffc',
+          'transition-property': 'background-color, line-color, target-arrow-color',
+          'transition-duration': '0.5s'
+        }),
+
+      elements: elements,
+
+
+      layout: {
+        name: 'breadthfirst'
+      }
+
+    });
+
+    var options = {
+      name: 'breadthfirst',
+
+      fit: true, // whether to fit the viewport to the graph
+      directed: false, // whether the tree is directed downwards (or edges can point in any direction if false)
+      padding: 30, // padding on fit
+      circle: false, // put depths in concentric circles if true, put depths top down if false
+      spacingFactor: 1.75, // positive spacing factor, larger => more space between nodes (N.B. n/a if causes overlap)
+      boundingBox: undefined, // constrain layout bounds; { x1, y1, x2, y2 } or { x1, y1, w, h }
+      avoidOverlap: true, // prevents node overlap, may overflow boundingBox if not enough space
+      roots: undefined, // the roots of the trees
+      maximalAdjustments: 0, // how many times to try to position the nodes in a maximal way (i.e. no backtracking)
+      animate: false, // whether to transition the node positions
+      animationDuration: 500, // duration of animation in ms if enabled
+      ready: undefined, // callback on layoutready
+      stop: undefined // callback on layoutstop
+    };
+
+    cy.layout(options);
+  }
+
+
+  $(function () { // on dom ready
+
+    view_cose();
+
+  }); // on dom ready
 </script>
 
 
 <div id="results" class="row">
-<div class="small-12 columns">
-<ul class="tabs" data-tabs id="subnav-tabs">
+  <div class="small-12 columns">
+    <ul class="tabs" data-tabs id="subnav-tabs">
 
-  <li id="sub_nav_cose" class="tabs-title"><a href="#" onclick="view_cose();">Cose</a></li>
-  <li id="sub_nav_circle" class="tabs-title"><a href="#" onclick="view_circle();">Circle</a></li>
-  <li id="sub_nav_breadthfirst" class="tabs-title"><a href="#" onclick="view_breadthfirst();">Breadthfirst</a></li>
-  <li id="sub_nav_concentric" class="tabs-title"><a href="#" onclick="view_concentric();">Concentric</a></li>
-  <li id="sub_nav_grid" class="tabs-title"><a href="#" onclick="view_grid();">Grid</a></li>
+      <li id="sub_nav_cose" class="tabs-title"><a href="#"
+                                                  onclick="view_cose();">Cose</a>
+      </li>
+      <li id="sub_nav_circle" class="tabs-title"><a href="#"
+                                                    onclick="view_circle();">Circle</a>
+      </li>
+      <li id="sub_nav_breadthfirst" class="tabs-title"><a href="#"
+                                                          onclick="view_breadthfirst();">Breadthfirst</a>
+      </li>
+      <li id="sub_nav_concentric" class="tabs-title"><a href="#"
+                                                        onclick="view_concentric();">Concentric</a>
+      </li>
+      <li id="sub_nav_grid" class="tabs-title"><a href="#"
+                                                  onclick="view_grid();">Grid</a>
+      </li>
 
-</ul>
-</div>
+    </ul>
+  </div>
 
-<div class="small-12 columns" style="height: 120%; width=100%;" id="cy"></div>
+  <div class="small-12 columns" style="height: 120%; width=100%;" id="cy"></div>
 
-
-    
 
 </div>

--- a/src/templates/view.images.php
+++ b/src/templates/view.images.php
@@ -5,7 +5,7 @@
 ?>
 
 <div id="results" class="row">
-  <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-3">
+  <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-3 no-bullet">
 
     <?php foreach ($results->response->docs as $doc):
 
@@ -82,7 +82,7 @@
         </div>
 
         <?php if ($author): ?>
-          <div class="author">$author</div>'
+          <div class="author"><?= $author ?></div>
         <?php endif; ?>
 
         <div class="title imagelist">

--- a/src/templates/view.images.php
+++ b/src/templates/view.images.php
@@ -6,9 +6,7 @@
 ?>
 
 <div id="results" class="row">
-
   <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-3">
-
     <?php
     foreach ($results->response->docs as $doc) {
 
@@ -77,7 +75,6 @@
 
         }
       }
-
       ?>
       <li>
         <div class="image">
@@ -99,7 +96,6 @@
 
         <div class="title imagelist">
 
-
           <a target="_blank" href="<?= $id ?>"><h2>
               <?php if ($title) { ?>
                 <?= $title ?>
@@ -111,11 +107,9 @@
 
         </div>
 
-
         <div class="snippet">
           <?= $snippet ?>
         </div>
-
 
         <div class="commands">
           <?php if ($uri_tip) { ?>
@@ -133,10 +127,8 @@
           | <?php print '<a target="_blank" href="preview.php?id=' . urlencode($id) . '">' . t('Preview') . '</a>'; ?>
         </div>
       </li>
-
       <?php
     } // foreach doc
     ?>
-
   </ul>
 </div>

--- a/src/templates/view.images.php
+++ b/src/templates/view.images.php
@@ -7,126 +7,136 @@
 
 <div id="results" class="row">
 
-<ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-3">
+  <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-3">
 
-<?php
-foreach ($results->response->docs as $doc) {
+    <?php
+    foreach ($results->response->docs as $doc) {
 
-  // URI
-  if (isset($doc->container_s)) {
-  	$id = $doc->container_s;
-  }
-  else {
-  	$id = $doc->id;
-  }
+      // URI
+      if (isset($doc->container_s)) {
+        $id = $doc->container_s;
+      }
+      else {
+        $id = $doc->id;
+      }
 
 
-  $uri_label = $id;
-  $uri_tip = false;
+      $uri_label = $id;
+      $uri_tip = FALSE;
 
-  // if file:// then only filename
-  if (strpos ($id, "file://")==0) {
-  	$uri_label = htmlspecialchars( basename($id) );
-  	// for tooptip remove file:// from beginning
-  	$uri_tip = htmlspecialchars( substr( $id, 7 ) );
-  }
+      // if file:// then only filename
+      if (strpos($id, "file://") == 0) {
+        $uri_label = htmlspecialchars(basename($id));
+        // for tooptip remove file:// from beginning
+        $uri_tip = htmlspecialchars(substr($id, 7));
+      }
 
-  // Author
-  $author = htmlspecialchars($doc->author_s);
+      // Author
+      $author = htmlspecialchars($doc->author_s);
 
-  // Title
-  $title = false;
+      // Title
+      $title = FALSE;
 
-  if (isset($doc->title)) {
-    if (!empty($doc->title)) {
-    	$title= htmlspecialchars($doc->title);
-    }
-  }
+      if (isset($doc->title)) {
+        if (!empty($doc->title)) {
+          $title = htmlspecialchars($doc->title);
+        }
+      }
 
-  // Type
-  $type= $doc->content_type;
+      // Type
+      $type = $doc->content_type;
 
-  // Modified date
-  if (isset($doc->file_modified_dt)) {
-	$datetime = $doc->file_modified_dt;
-  } elseif (isset($doc->last_modified)) {
-  	$datetime = $doc->last_modified;
-  } else {
-  	$datetime=false;
-  }
+      // Modified date
+      if (isset($doc->file_modified_dt)) {
+        $datetime = $doc->file_modified_dt;
+      }
+      elseif (isset($doc->last_modified)) {
+        $datetime = $doc->last_modified;
+      }
+      else {
+        $datetime = FALSE;
+      }
 
-  // File size
-  $file_size=0;
-  $file_size_txt = '';
-  if (isset($doc->file_size_i)) {
-  	$file_size = $doc->file_size_i;
-  	$file_size_txt = filesize_formatted($file_size);
-  }
+      // File size
+      $file_size = 0;
+      $file_size_txt = '';
+      if (isset($doc->file_size_i)) {
+        $file_size = $doc->file_size_i;
+        $file_size_txt = filesize_formatted($file_size);
+      }
 
-  // Snippet
-  if (isset($results->highlighting->$id->content)) {
-    $snippet = $results->highlighting->$id->content[0];
-  } else {
-	$snippet = $doc->content;
-	if (strlen($snippet) > $snippetsize) {
-		$snippet = substr($snippet,0,$snippetsize)."...";
-		$snippet = htmlspecialchars($snippet);
+      // Snippet
+      if (isset($results->highlighting->$id->content)) {
+        $snippet = $results->highlighting->$id->content[0];
+      }
+      else {
+        $snippet = $doc->content;
+        if (strlen($snippet) > $snippetsize) {
+          $snippet = substr($snippet, 0, $snippetsize) . "...";
+          $snippet = htmlspecialchars($snippet);
 
-	}
-  }
+        }
+      }
 
-?>
-<li>
-	<div class="image">
-		<a target="_blank" href="<?=$id?>">
-			<img width="200" src="<?=$id?>" <?php if ($title) { echo 'title="'.$title.'"'; } ?> />
-		</a>
-	</div>
-		
-	<div class="row">
-		<div class="date small-8 columns"><?=$datetime?></div>
-		<div class="size small-4 columns"><?=$file_size_txt?></div>	
-	</div>
-	
-	<?php if ($author) { print '<div class="author">'.$author.'</div>'; } ?>
-	
-	<div class="title imagelist">
-		
-			
-		<a target="_blank" href="<?=$id?>"><h2>
-		<?php if ($title) { ?>
-			<?=$title ?>
-		<?php } else { ?>
-			<?=$uri_label?>
-		<?php } ?>
-		</h2>
-		</a>
-		
-	</div>
-	
-	
-	<div class="snippet">
-<?=$snippet?>
-	</div>
-	
+      ?>
+      <li>
+        <div class="image">
+          <a target="_blank" href="<?= $id ?>">
+            <img width="200" src="<?= $id ?>" <?php if ($title) {
+              echo 'title="' . $title . '"';
+            } ?> />
+          </a>
+        </div>
 
-	<div class="commands">
-					<?php if ($uri_tip) { ?>
-					<span data-tooltip class="has-tip" title="<?=$uri_tip?>">
+        <div class="row">
+          <div class="date small-8 columns"><?= $datetime ?></div>
+          <div class="size small-4 columns"><?= $file_size_txt ?></div>
+        </div>
+
+        <?php if ($author) {
+          print '<div class="author">' . $author . '</div>';
+        } ?>
+
+        <div class="title imagelist">
+
+
+          <a target="_blank" href="<?= $id ?>"><h2>
+              <?php if ($title) { ?>
+                <?= $title ?>
+              <?php } else { ?>
+                <?= $uri_label ?>
+              <?php } ?>
+            </h2>
+          </a>
+
+        </div>
+
+
+        <div class="snippet">
+          <?= $snippet ?>
+        </div>
+
+
+        <div class="commands">
+          <?php if ($uri_tip) { ?>
+          <span data-tooltip class="has-tip" title="<?= $uri_tip ?>">
 				<?php } ?>
-				<a target="_blank" href="<?=$id?>"><?php echo t('open'); ?></a>
-					
-				
-				<?php if ($uri_tip) { ?>
+            <a target="_blank" href="<?= $id ?>"><?php echo t('open'); ?></a>
+
+
+            <?php if ($uri_tip) { ?>
 					</span>
-				<?php } ?>
-				<?php if ($cfg['metadata']['server']) { ?> | <a target="_blank" title="<?php echo t('meta description'); ?>" href="<?php print get_metadata_uri ($cfg['metadata']['server'], $id); ?>"><?php echo t('meta'); ?></a> <?php } ?> | <?php print '<a target="_blank" href="preview.php?id='.urlencode($id).'">' . t('Preview') . '</a>'; ?>
-	</div>
-</li>
+        <?php } ?>
+          <?php if ($cfg['metadata']['server']) { ?> | <a target="_blank"
+                                                          title="<?php echo t('meta description'); ?>"
+                                                          href="<?php print get_metadata_uri($cfg['metadata']['server'], $id); ?>"><?php echo t('meta'); ?></a> <?php } ?>
+          | <?php print '<a target="_blank" href="preview.php?id=' . urlencode($id) . '">' . t('Preview') . '</a>'; ?>
+        </div>
+      </li>
 
-<?php
-  } // foreach doc
-?>
+      <?php
+    } // foreach doc
+    ?>
 
-    </ul>
+  </ul>
 </div>

--- a/src/templates/view.images.php
+++ b/src/templates/view.images.php
@@ -1,14 +1,13 @@
 <?php
 // Standard view
 //
-// Show results as list
-
+// Show results as images
 ?>
 
 <div id="results" class="row">
   <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-3">
-    <?php
-    foreach ($results->response->docs as $doc) {
+
+    <?php foreach ($results->response->docs as $doc):
 
       // URI
       if (isset($doc->container_s)) {
@@ -18,12 +17,11 @@
         $id = $doc->id;
       }
 
-
       $uri_label = $id;
       $uri_tip = FALSE;
 
       // if file:// then only filename
-      if (strpos($id, "file://") == 0) {
+      if (strpos($id, 'file://') === 0) {
         $uri_label = htmlspecialchars(basename($id));
         // for tooptip remove file:// from beginning
         $uri_tip = htmlspecialchars(substr($id, 7));
@@ -35,24 +33,20 @@
       // Title
       $title = FALSE;
 
-      if (isset($doc->title)) {
-        if (!empty($doc->title)) {
-          $title = htmlspecialchars($doc->title);
-        }
+      if (!empty($doc->title)) {
+        $title = htmlspecialchars($doc->title);
       }
 
       // Type
       $type = $doc->content_type;
 
       // Modified date
+      $datetime = FALSE;
       if (isset($doc->file_modified_dt)) {
         $datetime = $doc->file_modified_dt;
       }
       elseif (isset($doc->last_modified)) {
         $datetime = $doc->last_modified;
-      }
-      else {
-        $datetime = FALSE;
       }
 
       // File size
@@ -72,16 +66,13 @@
         if (strlen($snippet) > $snippetsize) {
           $snippet = substr($snippet, 0, $snippetsize) . "...";
           $snippet = htmlspecialchars($snippet);
-
         }
-      }
-      ?>
+      } ?>
+
       <li>
         <div class="image">
           <a target="_blank" href="<?= $id ?>">
-            <img width="200" src="<?= $id ?>" <?php if ($title) {
-              echo 'title="' . $title . '"';
-            } ?> />
+            <img width="200" src="<?= $id ?>" <?= $title ? 'title="' . $title . '"' : '' ?> />
           </a>
         </div>
 
@@ -90,21 +81,12 @@
           <div class="size small-4 columns"><?= $file_size_txt ?></div>
         </div>
 
-        <?php if ($author) {
-          print '<div class="author">' . $author . '</div>';
-        } ?>
+        <?php if ($author): ?>
+          <div class="author">$author</div>'
+        <?php endif; ?>
 
         <div class="title imagelist">
-
-          <a target="_blank" href="<?= $id ?>"><h2>
-              <?php if ($title) { ?>
-                <?= $title ?>
-              <?php } else { ?>
-                <?= $uri_label ?>
-              <?php } ?>
-            </h2>
-          </a>
-
+          <a href="<?= $id ?>"><h2><?= $title ? $title : $uri_label ?></h2></a>
         </div>
 
         <div class="snippet">
@@ -112,23 +94,23 @@
         </div>
 
         <div class="commands">
-          <?php if ($uri_tip) { ?>
-          <span data-tooltip class="has-tip" title="<?= $uri_tip ?>">
-				<?php } ?>
-            <a target="_blank" href="<?= $id ?>"><?php echo t('open'); ?></a>
 
+          <?php if ($uri_tip): ?>
+            <span data-tooltip class="has-tip" title="<?= $uri_tip ?>">
+              <a href="<?= $id ?>"><?= t('open'); ?></a>
+            </span>
+          <?php else: ?>
+            <a href="<?= $id ?>"><?= t('open'); ?></a>
+          <?php endif; ?>
 
-            <?php if ($uri_tip) { ?>
-					</span>
-        <?php } ?>
-          <?php if ($cfg['metadata']['server']) { ?> | <a target="_blank"
-                                                          title="<?php echo t('meta description'); ?>"
-                                                          href="<?php print get_metadata_uri($cfg['metadata']['server'], $id); ?>"><?php echo t('meta'); ?></a> <?php } ?>
-          | <?php print '<a target="_blank" href="preview.php?id=' . urlencode($id) . '">' . t('Preview') . '</a>'; ?>
+          <?php if ($cfg['metadata']['server']): ?>
+            | <a title="<?= t('meta description'); ?>"
+                 href="<?= get_metadata_uri($cfg['metadata']['server'], $id); ?>"><?= t('meta'); ?></a>
+          <?php endif; ?>
+          | <?= '<a href="preview.php?id=' . urlencode($id) . '">' . t('Preview') . '</a>'; ?>
+
         </div>
       </li>
-      <?php
-    } // foreach doc
-    ?>
+    <?php endforeach; ?>
   </ul>
 </div>

--- a/src/templates/view.index.php
+++ b/src/templates/view.index.php
@@ -1,15 +1,11 @@
 <html>
 <head>
   <title><?php
-
     echo t('Search');
     if ($query) {
       print ' ' . htmlspecialchars($query);
     }
-
     ?></title>
-
-
   <link rel="stylesheet" href="css/foundation.css">
 
   <script src="js/vendor/jquery.js"></script>
@@ -20,27 +16,23 @@
   <script type="text/javascript" src="jquery/jquery.autocomplete.js"></script>
   <script type="text/javascript" src="autocomplete.js"></script>
   <link rel="stylesheet" href="css/app.css" type="text/css"/>
+
 </head>
 <body>
 <?php
-
 if (file_exists("templates/custom/view.index.topbar.php")) {
   include "templates/custom/view.index.topbar.php";
 }
 else {
   include "templates/view.index.topbar.php";
-}
-?>
-
+} ?>
 <div class="row">
-
   <div id="searchform-wrapper" class="small-12 medium-8 large-9 columns">
     <?php
     /*
      * SearchForm
     */
     ?>
-
     <form id="searchform" accept-charset="utf-8" method="get">
 
       <?php echo $form_hidden_parameters ?>
@@ -71,107 +63,75 @@ else {
         <div class="row">
           <div id="search-op" class="small-12 columns">
             <fieldset class="fieldset">
-              <legend>Search operator:</legend>
-              <div class="small-12 large-12 columns">
-                Find:
-              </div>
-
+              <legend><?= t("Search operator:"); ?></legend>
+              <div class="small-12 large-12 columns"><?= t("Find:") ?></div>
               <div class="small-12 large-4 columns">
                 <input type="radio"
-                       name="operator" <?php if ($operator == 'OR') {
-                  print " checked";
-                } ?> value="OR"> At least one word (OR)
+                       name="operator" <?= ($operator == 'OR') ? 'checked' : '' ?>
+                       value="OR"> <?= t("At least one word (OR)") ?>
               </div>
               <div class="small-12 large-4 columns">
                 <input type="radio"
-                       name="operator" <?php if ($operator == 'AND') {
-                  print " checked";
-                } ?> value="AND"> All words (AND)
+                       name="operator" <?= ($operator == 'AND') ? 'checked' : '' ?>
+                       value="AND"> <?= t("All words (AND)") ?>
               </div>
               <div class="small-12 large-4 columns">
                 <input type="radio"
-                       name="operator" <?php if ($operator == 'Phrase') {
-                  print " checked";
-                } ?> value="Phrase"> Exact expression (Phrase)
+                       name="operator" <?= ($operator == 'Phrase') ? 'checked' : '' ?>
+                       value="Phrase"> <?= t("Exact expression (Phrase)") ?>
               </div>
             </fieldset>
           </div>
         </div>
 
-
         <div class="row">
           <div class="small-12 columns">
             <fieldset class="fieldset">
-              <legend>Semantic search &amp; fuzzy search</legend>
+              <legend><?= t('Semantic search &amp; fuzzy search') ?></legend>
               <div class="small-12 large-12 columns">
                 Also find:
               </div>
               <div class="small-12 large-6 columns">
                 <input type="checkbox" name="stemming" id="stemming"
-                       value="stemming"<?php if ($stemming == TRUE) {
-                  print " checked";
-                } ?>><label for="stemming">Other word forms (grammar &amp;
-                  stemming)</label>
+                       value="stemming" <?= ($stemming == TRUE) ? 'checked' : '' ?>>
+                <label
+                  for="stemming"><?= t('Other word forms (grammar &amp; stemming)') ?></label>
               </div>
               <div class="small-12 large-6 columns">
                 <input type="checkbox" name="synonyms" id="synonyms"
-                       value="synonyms"<?php if ($synonyms == TRUE) {
-                  print " checked";
-                } ?>><label for="synonyms">Synonyms & aliases</label>
+                       value="synonyms" <?= ($synonyms == TRUE) ? 'checked' : '' ?>>
+                <label for="synonyms"><?= t('Synonyms & aliases') ?></label>
               </div>
-
             </fieldset>
           </div>
         </div>
-
       </div>
-
     </form>
-
-
   </div>
-
-
 </div>
 
-
 <div class="row">
-
   <div id="main" class="small-12 medium-8 large-9 columns">
-
-
     <?php
-
     include 'templates/select_view.php';
-
-    ?>
-
-
-    <?php
-
     // if no results, show message
     if ($total == 0) {
       ?>
-      <div id="noresults" class="panel">
-
-
-        <?php
+      <div id="noresults" class="panel"><?php
         if ($error) {
-          print '<p>Error: </p><p>' . $error . '</p>';
+          print '<p>' . t('Error:') . '</p><p>' . $error . '</p>';
         }
         else {
-          // Todo: Vorschlag: (in allen Bereichen, Ähnliches)
+          // Todo: Use t() elsewhere as well.
           print t('No results');
-        }
-        ?>
+        } ?>
       </div>
-
       <?php
     } // total == 0
     else { // there are results documents
 
       if ($error) {
-        print '<p>Error:</p><p>' . $error . '</p>';
+        print '<p>' . t('Error:') . '</p><p>' . $error . '</p>';
       }
 
       // print the results with selected view template
@@ -192,24 +152,24 @@ else {
 
       }
       elseif ($view == 'images') {
-        include 'templates/select_sort.php';
 
+        include 'templates/select_sort.php';
         include 'templates/pagination.php';
         include 'templates/view.images.php';
         include 'templates/pagination.php';
 
       }
       elseif ($view == 'videos') {
-        include 'templates/select_sort.php';
 
+        include 'templates/select_sort.php';
         include 'templates/pagination.php';
         include 'templates/view.videos.php';
         include 'templates/pagination.php';
 
       }
       elseif ($view == 'audios') {
-        include 'templates/select_sort.php';
 
+        include 'templates/select_sort.php';
         include 'templates/pagination.php';
         include 'templates/view.audios.php';
         include 'templates/pagination.php';
@@ -225,11 +185,11 @@ else {
       elseif ($view == 'words') {
 
         include 'templates/view.words.php';
+
       }
       elseif ($view == 'graph') {
 
         include 'templates/view.graph.php';
-
 
       }
       elseif ($view == 'trend') {
@@ -251,18 +211,14 @@ else {
         include 'templates/pages.php';
 
       }
-
-
     } // if total <> 0: there were documents
     ?>
 
-  </div><?php // main ?>
-
+  </div><?php ?>
 
   <div id="sidebar" class="small-12 medium-4 large-3 columns">
-
     <?php
-    // if preview, schow metadata
+    // If preview, show metadata.
     if ($view == "preview") {
       include "templates/view.preview.sidebar.php";
     }
@@ -271,52 +227,16 @@ else {
       include "templates/view.facets.php";
     }
     ?>
-
   </div>
-
-
 </div>
 
-<?php // Wait indicator - will be activated on click = next search (which can take a while and additional clicks would make it worse) ?>
+<?php
+// Wait indicator - will be activated on click = next search (which can take a while and additional clicks would make it worse)
+?>
 <div id="wait">
   <img src="images/ajax-loader.gif">
-  <p><?php echo t('wait'); ?></p>
+  <p><?= t('wait'); ?></p>
 </div>
-
-<script type="text/javascript">
-
-  /*
-  * init foundation responsive framework
-  */
-  $(document).foundation();
-
-</script>
-
-
-<script type="text/javascript">
-
-  /*
-  * untoggle advanced search options on load
-  */
-
-
-  // we dont want to see animation on initial toggle off on load
-  $("#searchoptions").hide();
-
-
-</script>
-
-<script type="text/javascript">
-
-  /*
-   * display wait-indicator
-   */
-  function waiting_on() {
-    document.getElementById('wait').style.visibility = "visible";
-    return true;
-  }
-</script>
-
 
 </body>
 </html>

--- a/src/templates/view.index.php
+++ b/src/templates/view.index.php
@@ -41,18 +41,19 @@ else {
                value="<?php echo htmlspecialchars($query, ENT_QUOTES, 'utf-8'); ?>"/>
       </div>
 
-
       <div id="search-button" class="small-12 medium-2 large-2 columns">
 
         <input id="submit" type="submit" class="button postfix"
-               value="<?php echo t("Search"); ?>" onclick="waiting_on()"/>
+               value="<?= t("Search"); ?>"
+               onclick="waiting_on()"/>
       </div>
 
-      <button type="button" data-toggle="searchoptions">Search options</button>
+      <button type="button"
+              data-toggle="searchoptions"><?= t("Search options"); ?></button>
 
-
-      <div class="callout secondary small-12 columns" id="searchoptions"
-           data-toggler data-animate="slide-in-left slide-out-left">
+      <div class="callout searchoptions secondary small-12 columns"
+           id="searchoptions" data-toggler
+           data-animate="slide-in-left slide-out-left">
 
         <div class="row">
           <div class="small-12 columns">

--- a/src/templates/view.index.php
+++ b/src/templates/view.index.php
@@ -1,281 +1,313 @@
 <html>
 <head>
-<title><?php
+  <title><?php
 
-echo t('Search');
-if ($query) print ' '.htmlspecialchars($query);
+    echo t('Search');
+    if ($query) {
+      print ' ' . htmlspecialchars($query);
+    }
 
-?></title>
+    ?></title>
 
 
-<link rel="stylesheet" href="css/foundation.css">
+  <link rel="stylesheet" href="css/foundation.css">
 
-<script src="js/vendor/jquery.js"></script>
-<script src="js/vendor/what-input.js"></script>
-<script src="js/vendor/foundation.js"></script>
-<script src="js/app.js"></script>
+  <script src="js/vendor/jquery.js"></script>
+  <script src="js/vendor/what-input.js"></script>
+  <script src="js/vendor/foundation.js"></script>
+  <script src="js/app.js"></script>
 
-<script type="text/javascript" src="jquery/jquery.autocomplete.js"></script>
-<script type="text/javascript" src="autocomplete.js"></script>
-<link rel="stylesheet" href="css/app.css" type="text/css" />
+  <script type="text/javascript" src="jquery/jquery.autocomplete.js"></script>
+  <script type="text/javascript" src="autocomplete.js"></script>
+  <link rel="stylesheet" href="css/app.css" type="text/css"/>
 </head>
 <body>
 <?php
 
-if ( file_exists("templates/custom/view.index.topbar.php") ) {
-	include "templates/custom/view.index.topbar.php";
-} else {
-	include "templates/view.index.topbar.php";
+if (file_exists("templates/custom/view.index.topbar.php")) {
+  include "templates/custom/view.index.topbar.php";
+}
+else {
+  include "templates/view.index.topbar.php";
 }
 ?>
 
-<div class="row">  
-
-	<div id="searchform-wrapper" class="small-12 medium-8 large-9 columns">
-		<?php
-		/*
-		 * SearchForm
-		*/
-		?>
-
-		<form id="searchform" accept-charset="utf-8" method="get">
-
-		<?php echo $form_hidden_parameters ?>
-		<div id="search-field" class="small-12 medium-8 large-8 columns">
-			<input id="q" name="q" type="text" value="<?php echo htmlspecialchars($query, ENT_QUOTES, 'utf-8'); ?>" />
-		</div>
-
-		 
-		<div id="search-button" class="small-12 medium-2 large-2 columns">
-					
-			<input id="submit" type="submit" class="button postfix" value="<?php echo t("Search"); ?>" onclick="waiting_on()" />
-		</div>
-
-		<button type="button" data-toggle="searchoptions">Search options</button>
-		
-		
-		
-<div class="callout secondary small-12 columns" id="searchoptions" data-toggler data-animate="slide-in-left slide-out-left">
-
-<div class="row">
-<div class="small-12 columns">
-<h4>Search options</h4>
-  </div>
-  </div>
-
-  <div class="row">
-  <div id="search-op" class="small-12 columns">
-		<fieldset class="fieldset">
-			<legend>Search operator:</legend>
-			<div class="small-12 large-12 columns">
-			Find:
-			</div>
-			
-			<div class="small-12 large-4 columns">
-				<input type="radio" name="operator" <?php if ($operator=='OR') {print " checked";}?> value="OR"> At least one word (OR)
-			</div>
-			<div class="small-12 large-4 columns">
-				<input type="radio" name="operator" <?php if ($operator=='AND') {print " checked";}?> value="AND"> All words (AND)
-			</div>
-			<div class="small-12 large-4 columns">
-				<input type="radio" name="operator" <?php if ($operator=='Phrase') {print " checked";}?> value="Phrase"> Exact expression (Phrase)
-			</div>
-		</fieldset>
-	</div></div>
-		
-
-	<div class="row">
-	<div class="small-12 columns">
-		<fieldset class="fieldset">
-			<legend>Semantic search &amp; fuzzy search</legend>
-			<div class="small-12 large-12 columns">
-			Also find:
-			</div>
-			<div class="small-12 large-6 columns">
-				<input type="checkbox" name="stemming" id="stemming" value="stemming"<?php if ($stemming==true) {print " checked";}?>><label for="stemming">Other word forms (grammar &amp; stemming)</label>
-			</div>
-			<div class="small-12 large-6 columns">
-				<input type="checkbox" name="synonyms" id="synonyms" value="synonyms"<?php if ($synonyms==true) {print " checked";}?>><label for="synonyms">Synonyms & aliases</label>
-			</div>
-
-		</fieldset>
-	</div></div>
-
-</div>
-	
-		</form>		
-
-			
-	</div>
-
-
-</div>
-
-
 <div class="row">
 
-<div id="main" class="small-12 medium-8 large-9 columns">
+  <div id="searchform-wrapper" class="small-12 medium-8 large-9 columns">
+    <?php
+    /*
+     * SearchForm
+    */
+    ?>
+
+    <form id="searchform" accept-charset="utf-8" method="get">
+
+      <?php echo $form_hidden_parameters ?>
+      <div id="search-field" class="small-12 medium-8 large-8 columns">
+        <input id="q" name="q" type="text"
+               value="<?php echo htmlspecialchars($query, ENT_QUOTES, 'utf-8'); ?>"/>
+      </div>
 
 
+      <div id="search-button" class="small-12 medium-2 large-2 columns">
 
-	<?php
-	
-	include 'templates/select_view.php';
+        <input id="submit" type="submit" class="button postfix"
+               value="<?php echo t("Search"); ?>" onclick="waiting_on()"/>
+      </div>
 
-	?>
-	
-	
-	<?php 
-	
-	// if no results, show message
-	if ($total == 0) {
-		?>
-	<div id="noresults" class="panel">
+      <button type="button" data-toggle="searchoptions">Search options</button>
 
 
-		<?php
-		if ($error) {
-			print '<p>Error: </p><p>' . $error . '</p>';
-		} else {
-			// Todo: Vorschlag: (in allen Bereichen, Ähnliches)
-			print t('No results');
-		}
-		?>
-	</div>
+      <div class="callout secondary small-12 columns" id="searchoptions"
+           data-toggler data-animate="slide-in-left slide-out-left">
 
-	<?php
-	} // total == 0
-	else { // there are results documents
-		
-		if ($error) {
-			print '<p>Error:</p><p>' . $error . '</p>';
-		}
-		
-		// print the results with selected view template
-		if ($view == 'list') {
-			
-			include 'templates/select_sort.php';
-			
-			include 'templates/pagination.php';						
-			include 'templates/view.list.php';
-			include 'templates/pagination.php';
+        <div class="row">
+          <div class="small-12 columns">
+            <h4>Search options</h4>
+          </div>
+        </div>
 
-		} elseif ($view == 'preview') {
+        <div class="row">
+          <div id="search-op" class="small-12 columns">
+            <fieldset class="fieldset">
+              <legend>Search operator:</legend>
+              <div class="small-12 large-12 columns">
+                Find:
+              </div>
 
-			include 'templates/pagination.php';
-			include 'templates/view.preview.php';
-			include 'templates/pagination.php';
-
-		} elseif ($view == 'images') {
-			include 'templates/select_sort.php';
-				
-			include 'templates/pagination.php';
-			include 'templates/view.images.php';
-			include 'templates/pagination.php';
-
-		} elseif ($view == 'videos') {
-			include 'templates/select_sort.php';
-				
-			include 'templates/pagination.php';
-			include 'templates/view.videos.php';
-			include 'templates/pagination.php';
-
-		} elseif ($view == 'audios') {
-			include 'templates/select_sort.php';
-				
-			include 'templates/pagination.php';
-			include 'templates/view.audios.php';
-			include 'templates/pagination.php';
-
-		} elseif ($view == 'table') {
-
-			include 'templates/pagination.php';
-			include 'templates/view.table.php';
-			include 'templates/pagination.php';
-
-		} elseif ($view=='words') {
-
-			include 'templates/view.words.php';
-		} elseif ($view=='graph') {
-			
-				include 'templates/view.graph.php';
-					
-			
-		} elseif ($view=='trend') {
-
-			include 'templates/view.trend.php';
-
-		} elseif ($view == 'timeline') {
-
-			include 'templates/pagination.php';
-			include 'timeline.php';
-			include 'templates/pagination.php';
-
-		}
-		else {
-
-			include 'templates/pages.php';
-			include 'templates/view.list.php';
-			include 'templates/pages.php';
-
-		}
+              <div class="small-12 large-4 columns">
+                <input type="radio"
+                       name="operator" <?php if ($operator == 'OR') {
+                  print " checked";
+                } ?> value="OR"> At least one word (OR)
+              </div>
+              <div class="small-12 large-4 columns">
+                <input type="radio"
+                       name="operator" <?php if ($operator == 'AND') {
+                  print " checked";
+                } ?> value="AND"> All words (AND)
+              </div>
+              <div class="small-12 large-4 columns">
+                <input type="radio"
+                       name="operator" <?php if ($operator == 'Phrase') {
+                  print " checked";
+                } ?> value="Phrase"> Exact expression (Phrase)
+              </div>
+            </fieldset>
+          </div>
+        </div>
 
 
-	} // if total <> 0: there were documents
-	?>
+        <div class="row">
+          <div class="small-12 columns">
+            <fieldset class="fieldset">
+              <legend>Semantic search &amp; fuzzy search</legend>
+              <div class="small-12 large-12 columns">
+                Also find:
+              </div>
+              <div class="small-12 large-6 columns">
+                <input type="checkbox" name="stemming" id="stemming"
+                       value="stemming"<?php if ($stemming == TRUE) {
+                  print " checked";
+                } ?>><label for="stemming">Other word forms (grammar &amp;
+                  stemming)</label>
+              </div>
+              <div class="small-12 large-6 columns">
+                <input type="checkbox" name="synonyms" id="synonyms"
+                       value="synonyms"<?php if ($synonyms == TRUE) {
+                  print " checked";
+                } ?>><label for="synonyms">Synonyms & aliases</label>
+              </div>
 
-	</div><?php // main ?>
+            </fieldset>
+          </div>
+        </div>
 
-	
-	<div id="sidebar" class="small-12 medium-4 large-3 columns">
-	
-	<?php
-				// if preview, schow metadata
-				if ($view=="preview") {
-					include "templates/view.preview.sidebar.php";
-				}	
-				else {
-				// show facets
-					include "templates/view.facets.php";
-				}
-	?>	
-	
-	</div>
-	
-	
+      </div>
+
+    </form>
+
+
+  </div>
+
+
 </div>
-	
-	<?php // Wait indicator - will be activated on click = next search (which can take a while and additional clicks would make it worse) ?>
-	<div id="wait">
-		<img src="images/ajax-loader.gif">
-		<p><?php echo t('wait'); ?></p>
-	</div>
-
-	<script type="text/javascript">
-
-	/*
-	* init foundation responsive framework
-	*/
-    $(document).foundation();
-
-	</script>
-	
-
-	<script type="text/javascript">
-	
-	/*
-	* untoggle advanced search options on load 
-	*/
 
 
-	// we dont want to see animation on initial toggle off on load
-	$("#searchoptions").hide();
+<div class="row">
+
+  <div id="main" class="small-12 medium-8 large-9 columns">
 
 
-	</script>
+    <?php
 
-	<script type="text/javascript">
-	
+    include 'templates/select_view.php';
+
+    ?>
+
+
+    <?php
+
+    // if no results, show message
+    if ($total == 0) {
+      ?>
+      <div id="noresults" class="panel">
+
+
+        <?php
+        if ($error) {
+          print '<p>Error: </p><p>' . $error . '</p>';
+        }
+        else {
+          // Todo: Vorschlag: (in allen Bereichen, Ähnliches)
+          print t('No results');
+        }
+        ?>
+      </div>
+
+      <?php
+    } // total == 0
+    else { // there are results documents
+
+      if ($error) {
+        print '<p>Error:</p><p>' . $error . '</p>';
+      }
+
+      // print the results with selected view template
+      if ($view == 'list') {
+
+        include 'templates/select_sort.php';
+
+        include 'templates/pagination.php';
+        include 'templates/view.list.php';
+        include 'templates/pagination.php';
+
+      }
+      elseif ($view == 'preview') {
+
+        include 'templates/pagination.php';
+        include 'templates/view.preview.php';
+        include 'templates/pagination.php';
+
+      }
+      elseif ($view == 'images') {
+        include 'templates/select_sort.php';
+
+        include 'templates/pagination.php';
+        include 'templates/view.images.php';
+        include 'templates/pagination.php';
+
+      }
+      elseif ($view == 'videos') {
+        include 'templates/select_sort.php';
+
+        include 'templates/pagination.php';
+        include 'templates/view.videos.php';
+        include 'templates/pagination.php';
+
+      }
+      elseif ($view == 'audios') {
+        include 'templates/select_sort.php';
+
+        include 'templates/pagination.php';
+        include 'templates/view.audios.php';
+        include 'templates/pagination.php';
+
+      }
+      elseif ($view == 'table') {
+
+        include 'templates/pagination.php';
+        include 'templates/view.table.php';
+        include 'templates/pagination.php';
+
+      }
+      elseif ($view == 'words') {
+
+        include 'templates/view.words.php';
+      }
+      elseif ($view == 'graph') {
+
+        include 'templates/view.graph.php';
+
+
+      }
+      elseif ($view == 'trend') {
+
+        include 'templates/view.trend.php';
+
+      }
+      elseif ($view == 'timeline') {
+
+        include 'templates/pagination.php';
+        include 'timeline.php';
+        include 'templates/pagination.php';
+
+      }
+      else {
+
+        include 'templates/pages.php';
+        include 'templates/view.list.php';
+        include 'templates/pages.php';
+
+      }
+
+
+    } // if total <> 0: there were documents
+    ?>
+
+  </div><?php // main ?>
+
+
+  <div id="sidebar" class="small-12 medium-4 large-3 columns">
+
+    <?php
+    // if preview, schow metadata
+    if ($view == "preview") {
+      include "templates/view.preview.sidebar.php";
+    }
+    else {
+      // show facets
+      include "templates/view.facets.php";
+    }
+    ?>
+
+  </div>
+
+
+</div>
+
+<?php // Wait indicator - will be activated on click = next search (which can take a while and additional clicks would make it worse) ?>
+<div id="wait">
+  <img src="images/ajax-loader.gif">
+  <p><?php echo t('wait'); ?></p>
+</div>
+
+<script type="text/javascript">
+
+  /*
+  * init foundation responsive framework
+  */
+  $(document).foundation();
+
+</script>
+
+
+<script type="text/javascript">
+
+  /*
+  * untoggle advanced search options on load
+  */
+
+
+  // we dont want to see animation on initial toggle off on load
+  $("#searchoptions").hide();
+
+
+</script>
+
+<script type="text/javascript">
+
   /*
    * display wait-indicator
    */
@@ -285,6 +317,6 @@ if ( file_exists("templates/custom/view.index.topbar.php") ) {
   }
 </script>
 
-	
+
 </body>
 </html>

--- a/src/templates/view.index.topbar.php
+++ b/src/templates/view.index.topbar.php
@@ -1,20 +1,31 @@
 <div id="top-bar" class="top-bar">
 
-	<div class="top-bar-left">
+  <div class="top-bar-left">
 
-		<ul class="dropdown menu" data-dropdown-menu>
-		    <li><a href="./"><?php echo t("New search"); ?></a></li>
-		    <li><a href="./"><?php echo t("Newest documents"); ?></a></li>
-		    <li><a href="#" data-toggle="searchoptions"><?php echo t("advanced_search"); ?></a></li>
-		    <li><a target="_blank" title="Search with a list if there are results for each list entry" href="/search-apps/search-list/"><?php echo t("search_by_list"); ?></a></li>
-    		<li><a target="_blank" title="Manage structure, navigation and interactive filters by ontologies like thesauri or lists of named entities like organizations, persons or locations" href="/search-apps/thesaurus/"><?php echo t("manage_structure"); ?></a></li>
-    		<li><a target="_blank" title="Manage datasources" href="/search-apps/datasources/"><?php echo t("manage_datasources"); ?></a></li>
-		</ul>
-	</div>
-    
-	<div class="top-bar-right">
-    	<ul class="menu">
-    		<li><a target="_blank" href="<?=$uri_help?>"><?php echo t("Help"); ?></a></li>
-    	</ul>
-	</div>
+    <ul class="dropdown menu" data-dropdown-menu>
+      <li><a href="./"><?php echo t("New search"); ?></a></li>
+      <li><a href="./"><?php echo t("Newest documents"); ?></a></li>
+      <li><a href="#"
+             data-toggle="searchoptions"><?php echo t("advanced_search"); ?></a>
+      </li>
+      <li><a target="_blank"
+             title="Search with a list if there are results for each list entry"
+             href="/search-apps/search-list/"><?php echo t("search_by_list"); ?></a>
+      </li>
+      <li><a target="_blank"
+             title="Manage structure, navigation and interactive filters by ontologies like thesauri or lists of named entities like organizations, persons or locations"
+             href="/search-apps/thesaurus/"><?php echo t("manage_structure"); ?></a>
+      </li>
+      <li><a target="_blank" title="Manage datasources"
+             href="/search-apps/datasources/"><?php echo t("manage_datasources"); ?></a>
+      </li>
+    </ul>
+  </div>
+
+  <div class="top-bar-right">
+    <ul class="menu">
+      <li><a target="_blank"
+             href="<?= $uri_help ?>"><?php echo t("Help"); ?></a></li>
+    </ul>
+  </div>
 </div>

--- a/src/templates/view.list.php
+++ b/src/templates/view.list.php
@@ -75,11 +75,12 @@
       $author = htmlspecialchars($doc->author_s);
 
       // Title
-      $title = t('No title');
-      if (isset($doc->title)) {
-        if (!empty($doc->title)) {
-          $title = htmlspecialchars($doc->title);
-        }
+      // $title = t('No title');
+      if (!empty($doc->title)) {
+        $title = htmlspecialchars($doc->title);
+      }
+      else {
+        $title = $uri_label;
       }
 
       // Modified date
@@ -93,7 +94,6 @@
         $datetime = FALSE;
       }
 
-
       $file_size = 0;
       $file_size_txt = '';
       // File size
@@ -101,7 +101,6 @@
         $file_size = $doc->file_size_i;
         $file_size_txt = filesize_formatted($file_size);
       }
-
 
       // Snippet
       //print_r($results->highlighting->$id);

--- a/src/templates/view.list.php
+++ b/src/templates/view.list.php
@@ -6,275 +6,292 @@
 ?>
 
 <div id="results" class="row">
-    <ul class="no-bullet">
+  <ul class="no-bullet">
 
-<?php
+    <?php
 
-$result_nr = 0;
+    $result_nr = 0;
 
-foreach ($results->response->docs as $doc) {
+    foreach ($results->response->docs as $doc) {
 
-  $result_nr++;
+      $result_nr++;
 
-  $id = $doc->id;
-  
-  // Type
-  $type = $doc->content_type;
-  
-  // URI
-  
-  // if part of container like zip, link to container file
-  // if PDF page URI to Deeplink
-  // since PDF Reader can open deep links
-  if (isset($doc->container_s) and $type!='PDF page') {
-  	$uri = $doc->container_s;
-  	$deepid = $id;
-  
-  }
-  else {
-  	$uri = $id;
-  	$deepid = false;
-  }
-  
-  $uri_label = $uri;
-  $uri_tip = false;
-  
-  // if file:// then only filename
-  if (strpos ($uri, "file://")==0) {
-  	$uri_label = basename($uri);
-  	 
-  	// for tooptip remove file:// from beginning
-  	$uri_tip = substr( $uri, 7 );
-  	$uri_tip = htmlspecialchars($uri_tip);
-  	 
-  }
+      $id = $doc->id;
 
-  if ($deepid) {
-  	$deep_uri_label = $deepid;
-  	$deep_uri_label = htmlspecialchars($deep_uri_label);
-  	
-  	$deep_uri_tip = false;
-	// if file:// then only filename
-  	if (strpos ($deepid, "file://")==0) {
-  		$deep_uri_label = basename($deepid);
-  		$deep_uri_label = htmlspecialchars($deep_uri_label);
-  		
-  		// for tooltip remove file:// from beginning
-  		$deep_uri_tip = substr( $deepid, 7 );
-  		$deep_uri_tip = htmlspecialchars($deep_uri_tip);
-  		
-  	}
-  }
-  
-  $uri_unmasked = $uri;
-  $uri = htmlspecialchars($uri);
-  $uri_label = htmlspecialchars($uri_label);
-  
-  
-  // Author
-  $author = htmlspecialchars($doc->author_s);
+      // Type
+      $type = $doc->content_type;
 
-  // Title
-  $title = t('No title');
-  if (isset($doc->title)) {
-    if (!empty($doc->title)) {
-    	$title = htmlspecialchars($doc->title);
-    }
-  }
+      // URI
 
-  // Modified date
-  if (isset($doc->file_modified_dt)) {
-	$datetime = $doc->file_modified_dt; 
-  } elseif (isset($doc->last_modified)) {
-  	$datetime = $doc->last_modified;
-  } else {
-  	$datetime = false;
-  }
+      // if part of container like zip, link to container file
+      // if PDF page URI to Deeplink
+      // since PDF Reader can open deep links
+      if (isset($doc->container_s) and $type != 'PDF page') {
+        $uri = $doc->container_s;
+        $deepid = $id;
+
+      }
+      else {
+        $uri = $id;
+        $deepid = FALSE;
+      }
+
+      $uri_label = $uri;
+      $uri_tip = FALSE;
+
+      // if file:// then only filename
+      if (strpos($uri, "file://") == 0) {
+        $uri_label = basename($uri);
+
+        // for tooptip remove file:// from beginning
+        $uri_tip = substr($uri, 7);
+        $uri_tip = htmlspecialchars($uri_tip);
+
+      }
+
+      if ($deepid) {
+        $deep_uri_label = $deepid;
+        $deep_uri_label = htmlspecialchars($deep_uri_label);
+
+        $deep_uri_tip = FALSE;
+        // if file:// then only filename
+        if (strpos($deepid, "file://") == 0) {
+          $deep_uri_label = basename($deepid);
+          $deep_uri_label = htmlspecialchars($deep_uri_label);
+
+          // for tooltip remove file:// from beginning
+          $deep_uri_tip = substr($deepid, 7);
+          $deep_uri_tip = htmlspecialchars($deep_uri_tip);
+
+        }
+      }
+
+      $uri_unmasked = $uri;
+      $uri = htmlspecialchars($uri);
+      $uri_label = htmlspecialchars($uri_label);
 
 
-  $file_size=0;
-  $file_size_txt = '';	
-  // File size
-  if (isset($doc->file_size_i)) {
-  	$file_size = $doc->file_size_i;
-  	$file_size_txt = filesize_formatted($file_size);
-  }
-  
-  
-  
-  // Snippet
-  //print_r($results->highlighting->$id);
+      // Author
+      $author = htmlspecialchars($doc->author_s);
 
-  $snippets = array();
+      // Title
+      $title = t('No title');
+      if (isset($doc->title)) {
+        if (!empty($doc->title)) {
+          $title = htmlspecialchars($doc->title);
+        }
+      }
 
-  if (isset($results->highlighting->$id->content)) {
-    $snippets = $results->highlighting->$id->content;
-  }
+      // Modified date
+      if (isset($doc->file_modified_dt)) {
+        $datetime = $doc->file_modified_dt;
+      }
+      elseif (isset($doc->last_modified)) {
+        $datetime = $doc->last_modified;
+      }
+      else {
+        $datetime = FALSE;
+      }
 
-  foreach ($cfg['languages'] as $language) {
-	$language_specific_fieldname = 'content_txt_'.$language;
-	if (isset($results->highlighting->$id->$language_specific_fieldname)) {
-	    $snippets = $results->highlighting->$id->$language_specific_fieldname;
-  	}
-  }
 
- if (count($snippets) == 0 && isset($doc->content)) {
-  	// if no snippets available, use content as snippet
-	$snippets = array($doc->content);
-	// and cut it to snippet size
-	if (strlen($snippets[0]) > $cfg['snippetsize']) {
-		$snippets[0] = substr($snippets[0],0,$cfg['snippetsize'])."...";
-	}
-  }
+      $file_size = 0;
+      $file_size_txt = '';
+      // File size
+      if (isset($doc->file_size_i)) {
+        $file_size = $doc->file_size_i;
+        $file_size_txt = filesize_formatted($file_size);
+      }
 
-?>
-<li>
-	<a name="<?=$result_nr?>"/>
-	<div class="title"><a class="title" target="_blank" href="<?=$uri?>"><?=$title?></a></div>
-	
-	<div class="date"><?=$datetime?></div>
-	
-	<div>
+
+      // Snippet
+      //print_r($results->highlighting->$id);
+
+      $snippets = array();
+
+      if (isset($results->highlighting->$id->content)) {
+        $snippets = $results->highlighting->$id->content;
+      }
+
+      foreach ($cfg['languages'] as $language) {
+        $language_specific_fieldname = 'content_txt_' . $language;
+        if (isset($results->highlighting->$id->$language_specific_fieldname)) {
+          $snippets = $results->highlighting->$id->$language_specific_fieldname;
+        }
+      }
+
+      if (count($snippets) == 0 && isset($doc->content)) {
+        // if no snippets available, use content as snippet
+        $snippets = array($doc->content);
+        // and cut it to snippet size
+        if (strlen($snippets[0]) > $cfg['snippetsize']) {
+          $snippets[0] = substr($snippets[0], 0, $cfg['snippetsize']) . "...";
+        }
+      }
+
+      ?>
+      <li>
+        <a name="<?= $result_nr ?>"/>
+        <div class="title"><a class="title" target="_blank"
+                              href="<?= $uri ?>"><?= $title ?></a></div>
+
+        <div class="date"><?= $datetime ?></div>
+
+        <div>
 		<span class="uri">
 
-		<?php 
-		if ($deepid) {
-		?>
-					<?php if ($deep_uri_tip) { ?>
-					<span data-tooltip class="has-tip" title="<?=$deep_uri_tip?>">
+		<?php
+    if ($deepid) {
+      ?>
+      <?php if ($deep_uri_tip) { ?>
+        <span data-tooltip class="has-tip" title="<?= $deep_uri_tip ?>">
+      <?php } ?>
+      <?= $deep_uri_label ?>
+      <?php if ($deep_uri_tip) { ?>
+        </span>
+      <?php } ?>
+      in
+      <?php
+    } // if deepid
+    ?>
+
+      <?php if ($uri_tip) { ?>
+      <span data-tooltip class="has-tip" title="<?= $uri_tip ?>">
 				<?php } ?>
-			<?=$deep_uri_label?>
-				<?php if ($deep_uri_tip) { ?>
+        <?= $uri_label ?>
+        <?php if ($uri_tip) { ?>
 					</span>
-				<?php } ?>
-in
-		<?php 
-		} // if deepid
-		?>
-		
-		<?php if ($uri_tip) { ?>
-					<span data-tooltip class="has-tip" title="<?=$uri_tip?>">
-				<?php } ?>
-			<?=$uri_label?>
-				<?php if ($uri_tip) { ?>
-					</span>
-				<?php } ?>
+    <?php } ?>
 		</span>
-		<?php if ($file_size_txt) { ?>
-		<span class="size">(<?=$file_size_txt?>)</span>
-		<?php } // if filesize?>
-	</div>
-	
-	
-	<div class="snippets">
-		<?php if ($author) { print '<div class="author">'.$author.'</div>'; } ?>
-		<ul>
-<?php
-
-	$snippets_open = 3;
-	$snippet_number = 0;
-
-	foreach ($snippets as $snippet) {
-		$snippet_number++;
-
-		// open block with more snipets
-		if ($snippet_number == $snippets_open + 1) {
-			
-			print '</ul><ul class="more-snippets" id="'.$result_nr.'#more-snippets">';
-					
-		}
-		
-		print '<li class="snippet">' . $snippet . '</li>';
-
-		
-	}
+          <?php if ($file_size_txt) { ?>
+            <span class="size">(<?= $file_size_txt ?>)</span>
+          <?php } // if filesize?>
+        </div>
 
 
-?>
-		</ul>
-<?php
+        <div class="snippets">
+          <?php if ($author) {
+            print '<div class="author">' . $author . '</div>';
+          } ?>
+          <ul>
+            <?php
 
-	// if more snippets
-	if ($snippet_number > $snippets_open) {
+            $snippets_open = 3;
+            $snippet_number = 0;
 
-		print '<a class="tiny button" id="'.$result_nr.'#more-snippets-button" href="#'.$result_nr.'" onClick="document.getElementById(\''.$result_nr.'#more-snippets\').style.display = \'block\';document.getElementById(\''.$result_nr.'#more-snippets-button\').style.display = \'none\';">Show all '.$snippet_number.' snippets</a>';
-				
-	}
+            foreach ($snippets as $snippet) {
+              $snippet_number++;
 
-?>
+              // open block with more snipets
+              if ($snippet_number == $snippets_open + 1) {
 
-	</div>
-	
-	
-	<?php 		
-				$first = true;	
-				// Print all configurated facets, but the field of result, not the facet of all results
-				foreach ($cfg['facets'] as $field => $facet_config) {
+                print '</ul><ul class="more-snippets" id="' . $result_nr . '#more-snippets">';
 
-					
-					if ($field != '_text_' and $cfg['facets'][$field]['snippets_enabled']) {
-						if ( isset( $doc->$field ) ) {
-							
+              }
 
-							?>
-							
-									<span class="<?= $field ?>">
+              print '<li class="snippet">' . $snippet . '</li>';
+
+
+            }
+
+
+            ?>
+          </ul>
+          <?php
+
+          // if more snippets
+          if ($snippet_number > $snippets_open) {
+
+            print '<a class="tiny button" id="' . $result_nr . '#more-snippets-button" href="#' . $result_nr . '" onClick="document.getElementById(\'' . $result_nr . '#more-snippets\').style.display = \'block\';document.getElementById(\'' . $result_nr . '#more-snippets-button\').style.display = \'none\';">Show all ' . $snippet_number . ' snippets</a>';
+
+          }
+
+          ?>
+
+        </div>
+
+
+        <?php
+        $first = TRUE;
+        // Print all configurated facets, but the field of result, not the facet of all results
+        foreach ($cfg['facets'] as $field => $facet_config) {
+
+
+          if ($field != '_text_' and $cfg['facets'][$field]['snippets_enabled']) {
+            if (isset($doc->$field)) {
+
+
+              ?>
+
+              <span class="<?= $field ?>">
 
 								
-								<span title="Extracted named entities or annotated tags"><?= $cfg['facets'][$field]['label'] ?>:</span>
-								<?php 
-								
-										if ( is_array ( $doc->$field ) ) {
+								<span
+                  title="Extracted named entities or annotated tags"><?= $cfg['facets'][$field]['label'] ?>
+                  :</span>
+                <?php
 
-											$entities_open = $cfg['facets'][$field]['snippets_limit'];
-											$entity_number = 0;
+                if (is_array($doc->$field)) {
 
-											foreach ($doc->$field as $value) {
-		$entity_number++;
+                  $entities_open = $cfg['facets'][$field]['snippets_limit'];
+                  $entity_number = 0;
 
-		// open block with more snipets
-		if ($entity_number == $entities_open + 1) {
-			
-			print '<span class="more-snippets" id="'.$result_nr.$field.'#more-snippets">';
-					
-		}
+                  foreach ($doc->$field as $value) {
+                    $entity_number++;
 
-												if ($entity_number > 1) { print ', '; }
-												print htmlspecialchars($value);
-											}
-	// if more snippets
-	if ($entity_number > $entities_open) {
+                    // open block with more snipets
+                    if ($entity_number == $entities_open + 1) {
 
-		print '</span><a class="tiny button" id="'.$result_nr.$field.'#more-snippets-button" href="#'.$result_nr.$field.'" onClick="document.getElementById(\''.$result_nr.$field.'#more-snippets\').style.display = \'inline\';document.getElementById(\''.$result_nr.$field.'#more-snippets-button\').style.display = \'none\';" title="Show all '.$entity_number.' '.$cfg['facets'][$field]['label'].'">More</a>';
-				
-	}
-									
+                      print '<span class="more-snippets" id="' . $result_nr . $field . '#more-snippets">';
+
+                    }
+
+                    if ($entity_number > 1) {
+                      print ', ';
+                    }
+                    print htmlspecialchars($value);
+                  }
+                  // if more snippets
+                  if ($entity_number > $entities_open) {
+
+                    print '</span><a class="tiny button" id="' . $result_nr . $field . '#more-snippets-button" href="#' . $result_nr . $field . '" onClick="document.getElementById(\'' . $result_nr . $field . '#more-snippets\').style.display = \'inline\';document.getElementById(\'' . $result_nr . $field . '#more-snippets-button\').style.display = \'none\';" title="Show all ' . $entity_number . ' ' . $cfg['facets'][$field]['label'] . '">More</a>';
+
+                  }
 
 
-										} else {
-											if ($first) {$first=false;} else { print ', '; }
-											print $doc->$field;
-										}
-										?>
+                }
+                else {
+                  if ($first) {
+                    $first = FALSE;
+                  }
+                  else {
+                    print ', ';
+                  }
+                  print $doc->$field;
+                }
+                ?>
 									</span>
-									<?php
-							}
-					}		
-				}
+              <?php
+            }
+          }
+        }
 
-	?>
-	
-	
-	<div class="commands">
-		<a target="_blank" href="<?=$uri?>"><?php echo t('open'); ?></a> <?php if ($cfg['metadata']['server']) { ?> | <a target="_blank" title="<?php echo t('meta description'); ?>" href="<?php print get_metadata_uri ($cfg['metadata']['server'], $uri_unmasked); ?>"><?php echo t('meta'); ?></a> <?php } ?> | <?php print '<a target="_blank" href="preview.php?id='.urlencode($uri_unmasked).'">' . t('Preview') . '</a>'; ?>
-	</div>
-</li>
+        ?>
 
-<?php
-  } // foreach doc
-?>
 
-    </ul>
-    
+        <div class="commands">
+          <a target="_blank"
+             href="<?= $uri ?>"><?php echo t('open'); ?></a> <?php if ($cfg['metadata']['server']) { ?> |
+            <a target="_blank" title="<?php echo t('meta description'); ?>"
+               href="<?php print get_metadata_uri($cfg['metadata']['server'], $uri_unmasked); ?>"><?php echo t('meta'); ?></a> <?php } ?>
+          | <?php print '<a target="_blank" href="preview.php?id=' . urlencode($uri_unmasked) . '">' . t('Preview') . '</a>'; ?>
+        </div>
+      </li>
+
+      <?php
+    } // foreach doc
+    ?>
+
+  </ul>
+
 </div>
 

--- a/src/templates/view.list.php
+++ b/src/templates/view.list.php
@@ -1,21 +1,17 @@
 <?php
-// Standard view
+// Standard view: a list.
 //
-// Show results as list
 
+// Number of snippets initially displayed.
+$snippets_open = 3;
 ?>
 
 <div id="results" class="row">
   <ul class="no-bullet">
-
     <?php
-
     $result_nr = 0;
-
-    foreach ($results->response->docs as $doc) {
-
+    foreach ($results->response->docs as $doc):
       $result_nr++;
-
       $id = $doc->id;
 
       // Type
@@ -126,171 +122,123 @@
           $snippets[0] = substr($snippets[0], 0, $cfg['snippetsize']) . "...";
         }
       }
-
       ?>
-      <li>
-        <a name="<?= $result_nr ?>"/>
-        <div class="title"><a class="title" target="_blank"
-                              href="<?= $uri ?>"><?= $title ?></a></div>
-
-        <div class="date"><?= $datetime ?></div>
-
-        <div>
-		<span class="uri">
-
-		<?php
-    if ($deepid) {
-      ?>
-      <?php if ($deep_uri_tip) { ?>
-        <span data-tooltip class="has-tip" title="<?= $deep_uri_tip ?>">
-      <?php } ?>
-      <?= $deep_uri_label ?>
-      <?php if ($deep_uri_tip) { ?>
-        </span>
-      <?php } ?>
-      in
-      <?php
-    } // if deepid
-    ?>
-
-      <?php if ($uri_tip) { ?>
-      <span data-tooltip class="has-tip" title="<?= $uri_tip ?>">
-				<?php } ?>
-        <?= $uri_label ?>
-        <?php if ($uri_tip) { ?>
-					</span>
-    <?php } ?>
-		</span>
-          <?php if ($file_size_txt) { ?>
-            <span class="size">(<?= $file_size_txt ?>)</span>
-          <?php } // if filesize?>
+      <li id="<?= $result_nr ?>">
+        <div class="title"><a class="title" href="<?= $uri ?>"><?= $title ?></a>
         </div>
-
+        <div class="date"><?= $datetime ?></div>
+        <div>
+          <span class="uri">
+            <?php if ($deepid): ?>
+              <?php if ($deep_uri_tip): ?>
+                <span data-tooltip class="has-tip" title="<?= $deep_uri_tip ?>">
+              <?php endif; ?>
+              <?= $deep_uri_label ?>
+              <?php if ($deep_uri_tip): ?>
+                </span>
+              <?php endif; ?>
+              in
+            <?php endif; ?>
+            <?php if ($uri_tip): ?>
+            <span data-tooltip class="has-tip" title="<?= $uri_tip ?>">
+            <?php endif; ?>
+            <?= $uri_label ?>
+            <?php if ($uri_tip): ?>
+              </span>
+          <?php endif; ?>
+          </span>
+          <?php if ($file_size_txt): ?>
+            <span class="size">(<?= $file_size_txt ?>)</span>
+          <?php endif; ?>
+        </div>
 
         <div class="snippets">
-          <?php if ($author) {
-            print '<div class="author">' . $author . '</div>';
-          } ?>
+          <?php if ($author): ?>
+            <div class="author"><?= $author ?></div>
+          <?php endif; ?>
           <ul>
-            <?php
+            <?php $snippet_number = 0; ?>
+            <?php foreach ($snippets
 
-            $snippets_open = 3;
-            $snippet_number = 0;
-
-            foreach ($snippets as $snippet) {
-              $snippet_number++;
-
-              // open block with more snipets
-              if ($snippet_number == $snippets_open + 1) {
-
-                print '</ul><ul class="more-snippets" id="' . $result_nr . '#more-snippets">';
-
-              }
-
-              print '<li class="snippet">' . $snippet . '</li>';
-
-
-            }
-
-
-            ?>
+            as $snippet): ?>
+            <?php if (++$snippet_number == ($snippets_open + 1)): ?>
           </ul>
-          <?php
-
-          // if more snippets
-          if ($snippet_number > $snippets_open) {
-
-            print '<a class="tiny button" id="' . $result_nr . '#more-snippets-button" href="#' . $result_nr . '" onClick="document.getElementById(\'' . $result_nr . '#more-snippets\').style.display = \'block\';document.getElementById(\'' . $result_nr . '#more-snippets-button\').style.display = \'none\';">Show all ' . $snippet_number . ' snippets</a>';
-
-          }
-
-          ?>
-
+          <ul class="more-snippets" id="<?= $result_nr ?>#more-snippets">
+            <?php endif; ?>
+            <li class="snippet"><?= $snippet ?></li>
+            <?php endforeach; ?>
+          </ul>
+          <?php if ($snippet_number > $snippets_open): ?>
+            <a class="tiny button" id="<?= $result_nr ?>#more-snippets-button"
+               href="#<?= $result_nr ?>"
+               onClick="
+                 document.getElementById('<?= $result_nr ?>#more-snippets').style.display = 'block';
+                 document.getElementById('<?= $result_nr ?>#more-snippets-button').style.display = 'none';
+                 "><?= t("Show all " . $snippet_number . " snippets") ?></a>
+          <?php endif; ?>
         </div>
-
 
         <?php
-        $first = TRUE;
-        // Print all configurated facets, but the field of result, not the facet of all results
-        foreach ($cfg['facets'] as $field => $facet_config) {
+        $first_facet = TRUE;
+        // Print all configured facets, but the field of result, not the facet of all results.
+        foreach ($cfg['facets'] as $field => $facet_config): ?>
+          <?php $first_value = TRUE; ?>
+          <?php if ($field != '_text_' and $cfg['facets'][$field]['snippets_enabled']): ?>
+            <?php if (isset($doc->$field)): ?>
+              <?= ($first_facet) ? '' : '; ' ?>
+              <?php $first_facet = FALSE; ?>
+            <span class="<?= $field ?>">
+              <span
+                title="<?= t("Extracted named entities or annotated tags") ?>">
+                  <?= $cfg['facets'][$field]['label'] ?>:
+                </span>
+              <?php if (is_array($doc->$field)): ?>
+                <?php $entities_open = $cfg['facets'][$field]['snippets_limit']; ?>
+                <?php $entity_number = 0; ?>
+                <?php foreach ($doc->$field as $value): ?>
+                  <?php if (++$entity_number == ($entities_open + 1)): ?>
+                    </span>
+                    <span class="more-snippets" id="<?= $result_nr ?><?= $field ?>#more-snippets">
+                    <ul class="more-snippets" id="<?= $result_nr ?>#more-snippets">
+                  <?php endif; ?>
+                    <?= ($entity_number > 1) ? ', ' : '' ?>
+                    <span
+                    class="facet-value"><?= htmlspecialchars($value) ?></span>
+                <?php endforeach; ?>
 
-
-          if ($field != '_text_' and $cfg['facets'][$field]['snippets_enabled']) {
-            if (isset($doc->$field)) {
-
-
-              ?>
-
-              <span class="<?= $field ?>">
-
-								
-								<span
-                  title="Extracted named entities or annotated tags"><?= $cfg['facets'][$field]['label'] ?>
-                  :</span>
-                <?php
-
-                if (is_array($doc->$field)) {
-
-                  $entities_open = $cfg['facets'][$field]['snippets_limit'];
-                  $entity_number = 0;
-
-                  foreach ($doc->$field as $value) {
-                    $entity_number++;
-
-                    // open block with more snipets
-                    if ($entity_number == $entities_open + 1) {
-
-                      print '<span class="more-snippets" id="' . $result_nr . $field . '#more-snippets">';
-
-                    }
-
-                    if ($entity_number > 1) {
-                      print ', ';
-                    }
-                    print htmlspecialchars($value);
-                  }
-                  // if more snippets
-                  if ($entity_number > $entities_open) {
-
-                    print '</span><a class="tiny button" id="' . $result_nr . $field . '#more-snippets-button" href="#' . $result_nr . $field . '" onClick="document.getElementById(\'' . $result_nr . $field . '#more-snippets\').style.display = \'inline\';document.getElementById(\'' . $result_nr . $field . '#more-snippets-button\').style.display = \'none\';" title="Show all ' . $entity_number . ' ' . $cfg['facets'][$field]['label'] . '">More</a>';
-
-                  }
-
-
-                }
-                else {
-                  if ($first) {
-                    $first = FALSE;
-                  }
-                  else {
-                    print ', ';
-                  }
-                  print $doc->$field;
-                }
-                ?>
-									</span>
-              <?php
-            }
-          }
-        }
-
-        ?>
-
+                  <?php if ($entity_number > $entities_open): ?>
+                  <a class="tiny button"
+                     id="<?= $result_nr ?><?= $field ?>#more-snippets-button"
+                     href="#<?= $result_nr ?><?= $field ?>"
+                     onClick="
+                       document.getElementById('<?= $result_nr ?><?= $field ?>#more-snippets').style.display = 'block';
+                       document.getElementById('<?= $result_nr ?><?= $field ?>#more-snippets-button').style.display = 'none';
+                       "
+                     title="Show all "<?= $entity_number ?> <?= $cfg['facets'][$field]['label'] ?>"><?= t('More') ?>
+                    </a>
+                <?php endif; ?>
+              <?php else: ?>
+                <?= ($first_value) ? '' : ', ' ?>
+                <span
+                  class="facet-value"><?= htmlspecialchars($doc->$field) ?></span>
+                <?php $first_value = FALSE; ?>
+              <?php endif; ?>
+              </span>
+            <?php endif; ?>
+          <?php endif; ?>
+        <?php endforeach; ?>
 
         <div class="commands">
-          <a target="_blank"
-             href="<?= $uri ?>"><?php echo t('open'); ?></a> <?php if ($cfg['metadata']['server']) { ?> |
-            <a target="_blank" title="<?php echo t('meta description'); ?>"
-               href="<?php print get_metadata_uri($cfg['metadata']['server'], $uri_unmasked); ?>"><?php echo t('meta'); ?></a> <?php } ?>
-          | <?php print '<a target="_blank" href="preview.php?id=' . urlencode($uri_unmasked) . '">' . t('Preview') . '</a>'; ?>
+          <a href="<?= $uri ?>"><?= t('open'); ?></a>
+          <?php if ($cfg['metadata']['server']): ?>
+            | <a title="<?= t('meta description'); ?>"
+                 href="<?= get_metadata_uri($cfg['metadata']['server'], $uri_unmasked); ?>"><?= t('meta'); ?></a>
+          <?php endif; ?>
+          | <a
+            href="preview.php?id='<?= urlencode($uri_unmasked) ?>"><?= t('Preview') ?></a>
         </div>
       </li>
-
-      <?php
-    } // foreach doc
-    ?>
-
+    <?php endforeach; ?>
   </ul>
-
 </div>
 

--- a/src/templates/view.preview.php
+++ b/src/templates/view.preview.php
@@ -53,7 +53,7 @@ if ($deepid) {
 // Author
 $author = htmlspecialchars($doc->author_s);
 // Title
-$title = "Ohne Titel";
+$title = t("No Title");
 if (isset($doc->title)) {
   if (!empty($doc->title)) {
     $title = htmlspecialchars($doc->title);

--- a/src/templates/view.preview.php
+++ b/src/templates/view.preview.php
@@ -5,386 +5,400 @@
 
 // todo: bei table alle fields ausser content?! und erst felder sammeln, dann html tabelle und for each field if exist
 foreach ($results->response->docs as $doc) {
-  $id = $doc->id;
+$id = $doc->id;
 
-  
-  // Type
-  $type= $doc->content_type; // todo: contentype schoener mit wertearray
-  
-  
-  // URI
-  
-  // if part of container like zip, link to container file
-  // if PDF page URI to Deeplink
-  // since PDF Reader can open deep links
-  if (isset($doc->container_s) and $type!='PDF page') {
-  	$uri = $doc->container_s;
-  	$deepid = $id;
 
+// Type
+$type = $doc->content_type; // todo: contentype schoener mit wertearray
+
+
+// URI
+
+// if part of container like zip, link to container file
+// if PDF page URI to Deeplink
+// since PDF Reader can open deep links
+if (isset($doc->container_s) and $type != 'PDF page') {
+  $uri = $doc->container_s;
+  $deepid = $id;
+
+}
+else {
+  $uri = $id;
+  $deepid = FALSE;
+}
+
+
+$uri_label = $uri;
+$uri_tip = FALSE;
+
+// if file:// then only filename
+if (strpos($uri, "file://") == 0) {
+  $uri_label = basename($uri);
+  // for tooptip remove file:// from beginning
+  $uri_tip = substr($uri, 7);
+}
+
+if ($deepid) {
+  $deep_uri_label = $deepid;
+  $deep_uri_tip = FALSE;
+  // if file:// then only filename
+  if (strpos($deepid, "file://") == 0) {
+    $deep_uri_label = basename($deepid);
+    // for tooptip remove file:// from beginning
+    $deep_uri_tip = substr($deepid, 7);
+  }
+}
+
+
+// Author
+$author = htmlspecialchars($doc->author_s);
+// Title
+$title = "Ohne Titel";
+if (isset($doc->title)) {
+  if (!empty($doc->title)) {
+    $title = htmlspecialchars($doc->title);
+  }
+}
+
+// Modified date
+if (isset($doc->file_modified_dt)) {
+  $datetime = $doc->file_modified_dt;
+}
+elseif (isset($doc->last_modified)) {
+  $datetime = $doc->last_modified;
+}
+else {
+  $datetime = FALSE;
+}
+
+// File size
+$file_size = 0;
+$file_size_txt = '';
+if (isset($doc->file_size_i)) {
+  $file_size = $doc->file_size_i;
+  $file_size_txt = filesize_formatted($file_size);
+}
+
+$preview_allowed = TRUE;
+
+# if not allowed in config
+if (isset($cfg['preview_allowed'])) {
+  if (!$cfg['preview_allowed']) {
+    $preview_allowed = FALSE;
+  }
+}
+
+# but ok, if allowed in this document
+if (isset($doc->preview_allowed_b)) {
+  if ($doc->preview_allowed_b == TRUE) {
+    $preview_allowed = TRUE;
   }
   else {
-  	$uri = $id;
-	$deepid = false;
+    $preview_allowed = FALSE;
   }
-  
-  
-  
-  $uri_label = $uri;
-  $uri_tip = false;
-  
-  // if file:// then only filename
-  if (strpos ($uri, "file://")==0) {
-  	$uri_label = basename($uri);
-  	// for tooptip remove file:// from beginning
-  	$uri_tip = substr( $uri, 7 );
-  }
-  
-  if ($deepid) {
-  	$deep_uri_label = $deepid;
-  	$deep_uri_tip = false;
-  	// if file:// then only filename
-  	if (strpos ($deepid, "file://")==0) {
-  		$deep_uri_label = basename($deepid);
-  		// for tooptip remove file:// from beginning
-  		$deep_uri_tip = substr( $deepid, 7 );
-  	}
-  }
-  
-  
-  // Author
-  $author = htmlspecialchars($doc->author_s);
-  // Title
-  $title="Ohne Titel";
-  if (isset($doc->title)) {
-    if (!empty($doc->title)) {
-    	$title= htmlspecialchars($doc->title);
+}
+
+if ($preview_allowed) {
+  //Content
+
+  $content = $doc->content;
+  $content = htmlspecialchars($content);
+
+  // if highligting available for the language, use highlighted content
+  foreach ($cfg['languages'] as $language) {
+    $language_specific_fieldname = 'content_txt_' . $language;
+    if (isset($results->highlighting->$id->$language_specific_fieldname)) {
+      $content = $results->highlighting->$id->$language_specific_fieldname[0];
     }
   }
 
-  // Modified date
-  if (isset($doc->file_modified_dt)) {
-	$datetime = $doc->file_modified_dt; 
-  } elseif (isset($doc->last_modified)) {
-  	$datetime = $doc->last_modified;
-  } else {
-  	$datetime=false;
-  }
-  
-  // File size
-  $file_size=0;
-  $file_size_txt = '';
-  if (isset($doc->file_size_i)) {
-  	$file_size = $doc->file_size_i;
-  	$file_size_txt = filesize_formatted($file_size);
+  $content = strip_empty_lines($content, 3);
+  $content = nl2br($content); // new lines
+
+
+  if (isset($cfg['preview_path']) and isset($doc->preview_s)) {
+    $preview_image = $cfg['preview_path'] . $doc->preview_s;
   }
 
-  $preview_allowed = true;
+}
+else {
+  $content = t('preview_not_allowed');
+}
 
-  # if not allowed in config
-  if (isset($cfg['preview_allowed'])) {
-  	if (!$cfg['preview_allowed'])
-  		$preview_allowed = false;
+
+//OCR
+$ocr = FALSE;
+if (isset($doc->ocr_t) && $preview_allowed) {
+  $ocr = strip_empty_lines($doc->ocr_t, 3);
+  $ocr = htmlspecialchars($ocr);
+  $ocr = nl2br($ocr); // new lines
+  if ($ocr == "") {
+    $ocr = FALSE;
   }
-  
-  # but ok, if allowed in this document
-  if (isset($doc->preview_allowed_b)) {
-	if ($doc->preview_allowed_b == true) {
-		$preview_allowed = true;
-	} else {
-		$preview_allowed = false;
-	}
-  }
-    
-  if ($preview_allowed) {
-  	//Content
+}
 
-	$content = $doc->content;
-	$content = htmlspecialchars( $content );
 
-	// if highligting available for the language, use highlighted content
-	foreach ($cfg['languages'] as $language) {
-		$language_specific_fieldname = 'content_txt_'.$language;
-		if (isset($results->highlighting->$id->$language_specific_fieldname)) {
-	    	$content = $results->highlighting->$id->$language_specific_fieldname[0];
-	  	}
- 	}
-	
-  	$content = strip_empty_lines($content, 3);
-  	$content = nl2br($content); // new lines
-  	 
-  	
-  	if (isset($cfg['preview_path']) and isset($doc->preview_s)) {
-  		$preview_image = $cfg['preview_path'] . $doc->preview_s;
-  	}
+// Find all columns (=fields)
+$cols = array();
 
-  }  else {
-	$content = t('preview_not_allowed');
-  }
-  
-  
-  //OCR
-  $ocr = false;
-  if (isset($doc->ocr_t) && $preview_allowed) {
-  	$ocr = strip_empty_lines($doc->ocr_t, 3);
-  	$ocr = htmlspecialchars($ocr);
-  	$ocr = nl2br($ocr); // new lines
-  	if ($ocr == "") $ocr=false;
-  }
-  
+$exclude_fields = array('_version_', 'content', 'preview_s', 'ocr_t');
 
-  
-  
-  // Find all columns (=fields)
-  $cols=array();
+// exclude fields that are only copied for language specific analysis in index
+foreach ($cfg['languages'] as $language) {
 
-  $exclude_fields = array('_version_','content','preview_s','ocr_t');
+  $exclude_fields[] = 'text_txt_' . $language;
+  $exclude_fields[] = 'content_txt_' . $language;
+  $exclude_fields[] = 'title_txt_' . $language;
+  $exclude_fields[] = 'description_txt_' . $language;
+  $exclude_fields[] = 'hashtag_ss_txt_' . $language;
 
-  // exclude fields that are only copied for language specific analysis in index
-  foreach ($cfg['languages'] as $language) {
+}
 
-	$exclude_fields[] = 'text_txt_'.$language;
-	$exclude_fields[] = 'content_txt_'.$language;
-	$exclude_fields[] = 'title_txt_'.$language;
-	$exclude_fields[] = 'description_txt_'.$language;
-	$exclude_fields[] = 'hashtag_ss_txt_'.$language;
+foreach ($doc as $field => $value) {
 
+  $exclude = FALSE;
+  if (in_array($field, $exclude_fields)) {
+    $exclude = TRUE;
   }
 
-  foreach ($doc as $field => $value) {
+  // if not yet there and not excluded, include field to cols
+  if (!in_array($field, $cols) && $exclude == FALSE) {
+    $cols[] = $field;
+  };
+}
 
-	$exclude = false;
-	if (in_array($field, $exclude_fields)) $exclude = true;
-
-	// if not yet there and not excluded, include field to cols
-  	if (!in_array($field, $cols) && $exclude == false) {
-  		$cols[] = $field;
-  	};
-  }
-  
-  asort($cols);
+asort($cols);
 
 ?>
 <div id="results" class="row">
 
-	<div class="date row">
-		<?=$datetime?>
-	</div>
+  <div class="date row">
+    <?= $datetime ?>
+  </div>
 
-	<div class="row">
+  <div class="row">
 		<span class="uri">
 		
-				<?php 
-		if ($deepid) {
-		?>
-					<?php if ($deep_uri_tip) { ?>
-					<span data-tooltip class="has-tip" title="<?=$deep_uri_tip?>">
+				<?php
+        if ($deepid) {
+          ?>
+          <?php if ($deep_uri_tip) { ?>
+            <span data-tooltip class="has-tip" title="<?= $deep_uri_tip ?>">
+          <?php } ?>
+          <?= $deep_uri_label ?>
+          <?php if ($deep_uri_tip) { ?>
+            </span>
+          <?php } ?>
+          in
+          <?php
+        } // if deepid
+        ?>
+
+      <?php if ($uri_tip) { ?>
+      <span data-tooltip class="has-tip" title="<?= $uri_tip ?>">
 				<?php } ?>
-			<?=$deep_uri_label?>
-				<?php if ($deep_uri_tip) { ?>
+        <?= $uri_label ?>
+        <?php if ($uri_tip) { ?>
 					</span>
-				<?php } ?>
-in
-		<?php 
-		} // if deepid
-		?>
-		
-				<?php if ($uri_tip) { ?>
-					<span data-tooltip class="has-tip" title="<?=$uri_tip?>">
-				<?php } ?>
-			<?=$uri_label?>
-				<?php if ($uri_tip) { ?>
-					</span>
-				<?php } ?>
+    <?php } ?>
 		</span>
-		<?php if ($file_size_txt) { ?>
-		<span class="size">(<?=$file_size_txt?>)</span>
-		<?php } // if filesize?>
-	</div>
-	
-	
-	<?php if ($author) { print '<div class="author row">'.$author.':</div>'; } ?>
-
-	
-	
-<div class="row">
-	<h1><a class="title" target="_blank" href="<?=$uri ?>"><?=$title ?></a></h1>
-	</div>
-	
-	<hr />
-
-	<div class="row">
+    <?php if ($file_size_txt) { ?>
+      <span class="size">(<?= $file_size_txt ?>)</span>
+    <?php } // if filesize?>
+  </div>
 
 
-<ul class="tabs" data-tabs id="preview-tabs">
+  <?php if ($author) {
+    print '<div class="author row">' . $author . ':</div>';
+  } ?>
 
-<?php if ($preview_image) { ?>
 
-<li class="tabs-title is-active"><a href="#preview-image" aria-selected="true">Preview</a></li>
-<li class="tabs-title"><a href="#preview-text">Text</a></li>
+  <div class="row">
+    <h1><a class="title" target="_blank" href="<?= $uri ?>"><?= $title ?></a>
+    </h1>
+  </div>
 
-<?php
+  <hr/>
+
+  <div class="row">
+
+
+    <ul class="tabs" data-tabs id="preview-tabs">
+
+      <?php if ($preview_image) { ?>
+
+        <li class="tabs-title is-active"><a href="#preview-image"
+                                            aria-selected="true">Preview</a>
+        </li>
+        <li class="tabs-title"><a href="#preview-text">Text</a></li>
+
+        <?php
 // if preview image
-} else {	?>
-<li class="tabs-title is-active"><a href="#preview-text" aria-selected="true">Text</a></li>
-<?php } // no preview image ?>
+      }
+      else { ?>
+        <li class="tabs-title is-active"><a href="#preview-text"
+                                            aria-selected="true">Text</a></li>
+      <?php } // no preview image ?>
 
-<?php if ($ocr) { ?>
-  <li class="tabs-title"><a href="#preview-ocr">OCR</a></li>
+      <?php if ($ocr) { ?>
+        <li class="tabs-title"><a href="#preview-ocr">OCR</a></li>
 
-<?php } // if ocr ?>
-  <li class="tabs-title"><a href="#preview-meta">Meta</a></li>
-  </ul>
-</div>
+      <?php } // if ocr ?>
+      <li class="tabs-title"><a href="#preview-meta">Meta</a></li>
+    </ul>
+  </div>
 
-<div class="tabs-content" data-tabs-content="preview-tabs">
-<?php if ($preview_image) { ?>
+  <div class="tabs-content" data-tabs-content="preview-tabs">
+    <?php if ($preview_image) { ?>
 
-<div class="tabs-panel is-active" id="preview-image">
-	<div class="panel">
-	<a href="<?=$id?>" target="_blank"><img src="<?=$preview_image?>" /></a>
-	</div>
-	
-</div>
-<div class="tabs-panel" id="preview-text">
-<?php
-// if preview image
-} else {	?>
-<div class="tabs-panel is-active" id="preview-text">
-<?php } // no preview image ?>
+    <div class="tabs-panel is-active" id="preview-image">
+      <div class="panel">
+        <a href="<?= $id ?>" target="_blank"><img src="<?= $preview_image ?>"/></a>
+      </div>
 
-	<div id="content">
-	
-	
-	
-		<?php
-		
-	if ($preview_allowed) {
-		
-		// if image
-		if (strpos ($type, 'image') === 0) { ?>
-		<a href="<?=$id?>" target="_blank"><img src="<?=$id?>" /></a>
-		<?php
-		} // if image
-	
-		// if video
-		if (strpos ($type, 'video') === 0) { ?>
-		<video controls="controls" src="<?=$id?>"></video>
-		<?php
-		} // if video
+    </div>
+    <div class="tabs-panel" id="preview-text">
+      <?php
+      // if preview image
+      } else { ?>
+      <div class="tabs-panel is-active" id="preview-text">
+        <?php } // no preview image ?>
 
-		// if audio
-		if (strpos ($type, 'audio') === 0) { ?>
-		<audio controls="controls" src="<?=$id?>"></audio>
-		<?php
-		} // if audio ?>
-	
-
-		<?php if ($type=='CSV row') {
-		
-		foreach ($cols as $col) {
-			if ($col!='id' and $col!='content_type' and $col!='container_s' and isset($doc->$col)) { ?>
-				<div>
-			<?php 
-				print "<b>" . htmlentities($col) . '</b>:<br />';
-
-				if ( is_array ( $doc->$col ) ) {
-					print "<ul>";
-					foreach ($doc->$col as $value) {
-						print '<li>' . htmlspecialchars($value) . '</li>';
-
-					}
-					print "</ul>";
-				}	
-				else {
-					print htmlspecialchars($doc->$col);
-				}
-					
-			
-				print '<br /><br />';
-			?>
-			</div>		
-			<?php
-		}
-}
-
-} // if csv row
-	
-	?>
-	
-		<?=$content?>
-
-		<?php		
-		if ($ocr) {
-			print "<b>" . t("content_ocr") ."</b><br/>";
-			print $ocr;
-		}
-		
-		
-	} // preview allowed
-	else {
-		print ( t('preview_not_allowed') );
-	}
-		?>
-		
-		
-	</div>
-</div>
-
-<?php if ($ocr && $preview_allowed) { ?>
-<div class="tabs-panel" id="preview-ocr">
-
-	<div id="ocr"><?php 
-		print "<i>" . t("content_ocr") ."</i><br/>";
-		?>
-		<?=$ocr?>
-	</div>
-</div>
-<?php } // if ocr ?>
-<div class="tabs-panel" id="preview-meta">
-	<div class="meta">
-<?php 
-foreach ($cols as $col) {
-		if (isset($doc->$col)) {
-			?>
-			<div>
-			<?php 
-			print "<b>" . htmlentities($col) . '</b>:<br />';
-
-				if ( is_array ( $doc->$col ) ) {
-					print "<ul>";
-					foreach ($doc->$col as $value) {
-						print '<li>' . htmlspecialchars($value) . '</li>';
-
-					}
-					print "</ul>";
-				}	
-				else {
-					print htmlspecialchars($doc->$col);
-				}
-					
-			
-			print '<br /><br />';
-			?>
-			</div>		
-			<?php
-		}
-}
-?>
-	</div>
-	
-</div>
+        <div id="content">
 
 
-</div>
+          <?php
 
-	<hr />
-	
-	<div class="commands">
-		<a target="_blank" href="<?=$uri?>"><?php echo t('open'); ?></a> <?php if ($cfg['metadata']['server']) { ?> | <a target="_blank" title="<?php echo t('meta description'); ?>" href="<?php print get_metadata_uri ($cfg['metadata']['server'], $id); ?>"><?php echo t('meta'); ?></a> <?php } ?>
-	</div>
+          if ($preview_allowed) {
 
-<?php
-  } // foreach doc
-?>
+            // if image
+            if (strpos($type, 'image') === 0) { ?>
+              <a href="<?= $id ?>" target="_blank"><img src="<?= $id ?>"/></a>
+              <?php
+            } // if image
 
-</div>
+            // if video
+            if (strpos($type, 'video') === 0) { ?>
+              <video controls="controls" src="<?= $id ?>"></video>
+              <?php
+            } // if video
+
+            // if audio
+            if (strpos($type, 'audio') === 0) { ?>
+              <audio controls="controls" src="<?= $id ?>"></audio>
+              <?php
+            } // if audio ?>
+
+
+            <?php if ($type == 'CSV row') {
+
+              foreach ($cols as $col) {
+                if ($col != 'id' and $col != 'content_type' and $col != 'container_s' and isset($doc->$col)) { ?>
+                  <div>
+                    <?php
+                    print "<b>" . htmlentities($col) . '</b>:<br />';
+
+                    if (is_array($doc->$col)) {
+                      print "<ul>";
+                      foreach ($doc->$col as $value) {
+                        print '<li>' . htmlspecialchars($value) . '</li>';
+
+                      }
+                      print "</ul>";
+                    }
+                    else {
+                      print htmlspecialchars($doc->$col);
+                    }
+
+
+                    print '<br /><br />';
+                    ?>
+                  </div>
+                  <?php
+                }
+              }
+
+            } // if csv row
+
+            ?>
+
+            <?= $content ?>
+
+            <?php
+            if ($ocr) {
+              print "<b>" . t("content_ocr") . "</b><br/>";
+              print $ocr;
+            }
+
+
+          } // preview allowed
+          else {
+            print (t('preview_not_allowed'));
+          }
+          ?>
+
+
+        </div>
+      </div>
+
+      <?php if ($ocr && $preview_allowed) { ?>
+        <div class="tabs-panel" id="preview-ocr">
+
+          <div id="ocr"><?php
+            print "<i>" . t("content_ocr") . "</i><br/>";
+            ?>
+            <?= $ocr ?>
+          </div>
+        </div>
+      <?php } // if ocr ?>
+      <div class="tabs-panel" id="preview-meta">
+        <div class="meta">
+          <?php
+          foreach ($cols as $col) {
+            if (isset($doc->$col)) {
+              ?>
+              <div>
+                <?php
+                print "<b>" . htmlentities($col) . '</b>:<br />';
+
+                if (is_array($doc->$col)) {
+                  print "<ul>";
+                  foreach ($doc->$col as $value) {
+                    print '<li>' . htmlspecialchars($value) . '</li>';
+
+                  }
+                  print "</ul>";
+                }
+                else {
+                  print htmlspecialchars($doc->$col);
+                }
+
+
+                print '<br /><br />';
+                ?>
+              </div>
+              <?php
+            }
+          }
+          ?>
+        </div>
+
+      </div>
+
+
+    </div>
+
+    <hr/>
+
+    <div class="commands">
+      <a target="_blank"
+         href="<?= $uri ?>"><?php echo t('open'); ?></a> <?php if ($cfg['metadata']['server']) { ?> |
+        <a target="_blank" title="<?php echo t('meta description'); ?>"
+           href="<?php print get_metadata_uri($cfg['metadata']['server'], $id); ?>"><?php echo t('meta'); ?></a> <?php } ?>
+    </div>
+
+    <?php
+    } // foreach doc
+    ?>
+
+  </div>

--- a/src/templates/view.preview.sidebar.php
+++ b/src/templates/view.preview.sidebar.php
@@ -2,86 +2,88 @@
 
 // print a facet and its values as links
 function print_field(&$doc, $field, $label) {
-	global $params;
+  global $params;
 
-	if ( isset( $doc->$field ) ) {
+  if (isset($doc->$field)) {
 
-		?>
-			<div id="<?= $field ?>" class="facet">
-				<h2>
-					<?= $label ?>
-				</h2>
-				<ul class="no-bullet">
-				<?php
-				if ( is_array ( $doc->$field ) ) {
-					foreach ($doc->$field as $value) {
-						print '<li>' . htmlspecialchars($value) . '</li>';
-					} 
-			
-				} else {
-					print htmlspecialchars($doc->$field);
-				}
-				?>
-				</ul>
-			</div>
-			<?php
-	}
+    ?>
+    <div id="<?= $field ?>" class="facet">
+      <h2>
+        <?= $label ?>
+      </h2>
+      <ul class="no-bullet">
+        <?php
+        if (is_array($doc->$field)) {
+          foreach ($doc->$field as $value) {
+            print '<li>' . htmlspecialchars($value) . '</li>';
+          }
+
+        }
+        else {
+          print htmlspecialchars($doc->$field);
+        }
+        ?>
+      </ul>
+    </div>
+    <?php
+  }
 }
 
 ?>
 <div id="facets">
-	
 
-				<?php if ($file_size_txt) { ?>
-				<div id="file_modified_dt" class="facet">
-				<h2>
-					<?php echo t('File date');  ?>
-				</h2>
 
-				
-				<ul class="no-bullet">
-				
-						<li><?=$datetime?></li>
-					
-				    </ul>
-				    
-				</div>
-				<?php } // if filedate ?>
-				
-				
-				
-				<?php if ($file_size_txt) { ?>
-				<div id="facet_file_size" class="facet">
-				<h2>
-					<?php echo t('file_size');  ?>
-				</h2>
+  <?php if ($file_size_txt) { ?>
+    <div id="file_modified_dt" class="facet">
+      <h2>
+        <?php echo t('File date'); ?>
+      </h2>
 
-				
-				<ul class="no-bullet">
-				
-						<li><span class="size"><?=$file_size_txt?></span></li>
-					
-				    </ul>
-				    
-				</div>
-				
-				<?php } // if filesize?>
-				
-				
-				
-				<?php 
-				
-				// print contenttype
-				print_field($doc, "content_type", t('Content type') );
-				
-				
-				
-				// Print all configurated facets, but the field of result, not the facet of all results
-				foreach ($cfg['facets'] as $facet => $facet_config) {
 
-					if ($facet != 'text') print_field($doc, $facet, t($facet_config['label']) );
-				}
+      <ul class="no-bullet">
 
-				?>
+        <li><?= $datetime ?></li>
+
+      </ul>
+
+    </div>
+  <?php } // if filedate ?>
+
+
+
+  <?php if ($file_size_txt) { ?>
+    <div id="facet_file_size" class="facet">
+      <h2>
+        <?php echo t('file_size'); ?>
+      </h2>
+
+
+      <ul class="no-bullet">
+
+        <li><span class="size"><?= $file_size_txt ?></span></li>
+
+      </ul>
+
+    </div>
+
+  <?php } // if filesize?>
+
+
+
+  <?php
+
+  // print contenttype
+  print_field($doc, "content_type", t('Content type'));
+
+
+  // Print all configurated facets, but the field of result, not the facet of all results
+  foreach ($cfg['facets'] as $facet => $facet_config) {
+
+    if ($facet != 'text') {
+      print_field($doc, $facet, t($facet_config['label']));
+    }
+  }
+
+  ?>
 
 </div>

--- a/src/templates/view.table.php
+++ b/src/templates/view.table.php
@@ -1,128 +1,130 @@
 <div class="table-scroll">
-<?php
+  <?php
 
-// View results as table with sortable columns
+  // View results as table with sortable columns
 
-// todo: exclude path*
+  // todo: exclude path*
 
-// todo: if sort spalte, dann diese in tabellenansicht rein, auch wenn kein feld (falls sort asc am anfang ohne werte und sortierung nicht umdrehbar)
-
+  // todo: if sort spalte, dann diese in tabellenansicht rein, auch wenn kein feld (falls sort asc am anfang ohne werte und sortierung nicht umdrehbar)
 
 
   // Find all columns (=fields)
-  $fields=array();
+  $fields = array();
 
-  $exclude_fields = array('_version_','content','preview_s');
+  $exclude_fields = array('_version_', 'content', 'preview_s');
 
   // exclude fields that are only copied for language specific analysis in index
   foreach ($cfg['languages'] as $language) {
 
-	$exclude_fields[] = 'text_txt_'.$language;
-	$exclude_fields[] = 'content_txt_'.$language;
-	$exclude_fields[] = 'title_txt_'.$language;
-	$exclude_fields[] = 'description_txt_'.$language;
-	$exclude_fields[] = 'hashtag_ss_txt_'.$language;
+    $exclude_fields[] = 'text_txt_' . $language;
+    $exclude_fields[] = 'content_txt_' . $language;
+    $exclude_fields[] = 'title_txt_' . $language;
+    $exclude_fields[] = 'description_txt_' . $language;
+    $exclude_fields[] = 'hashtag_ss_txt_' . $language;
 
   }
 
-foreach ($results->response->docs as $doc) {
-  foreach ($doc as $field => $value) {
+  foreach ($results->response->docs as $doc) {
+    foreach ($doc as $field => $value) {
 
-	$exclude = false;
-	if (in_array($field, $exclude_fields)) $exclude = true;
+      $exclude = FALSE;
+      if (in_array($field, $exclude_fields)) {
+        $exclude = TRUE;
+      }
 
-	// if not yet there and not excluded, include field to cols
-  	if (!in_array($field, $fields) && $exclude == false) {
-  		$fields[] = $field;
-  	};
+      // if not yet there and not excluded, include field to cols
+      if (!in_array($field, $fields) && $exclude == FALSE) {
+        $fields[] = $field;
+      };
+    }
   }
-}
 
-asort($fields);
+  asort($fields);
 
 
-// Table header and col names
+  // Table header and col names
 
-print '<table><thead><tr>'; // Temporary Style displays table in foreground
+  print '<table><thead><tr>'; // Temporary Style displays table in foreground
 
-print '<td>Query matchings</td>';
+  print '<td>Query matchings</td>';
 
-foreach ($fields as $field) {
-	// todo: sort link asc/desc
+  foreach ($fields as $field) {
+    // todo: sort link asc/desc
 
-	print '<th>';
-	
-	// if col is sorting col, highlight it
-	if ($sort==$field.' asc' or $sort==$field.' desc') {
-		print '<b>';
-	}
+    print '<th>';
 
-	// build sorting link and print linked column name
-	if ($sort==$field.' asc') {
-		print '<a title="'.htmlentities($field).'" onclick="waiting_on();" href="'.buildurl($params,"sort",$field.' desc','s',1).'">'.htmlentities( t($field) ).'</a>';
-	}
-	else {print '<a title="'.htmlentities($field).'" onclick="waiting_on();" href="'.buildurl($params,"sort",$field.' asc','s',1).'">'.htmlentities( t($field) ).'</a>';
-	}
+    // if col is sorting col, highlight it
+    if ($sort == $field . ' asc' or $sort == $field . ' desc') {
+      print '<b>';
+    }
 
-	if ($sort==$field.' asc' or $sort==$field.' desc') {
-		print '</b>';
-	}
+    // build sorting link and print linked column name
+    if ($sort == $field . ' asc') {
+      print '<a title="' . htmlentities($field) . '" onclick="waiting_on();" href="' . buildurl($params, "sort", $field . ' desc', 's', 1) . '">' . htmlentities(t($field)) . '</a>';
+    }
+    else {
+      print '<a title="' . htmlentities($field) . '" onclick="waiting_on();" href="' . buildurl($params, "sort", $field . ' asc', 's', 1) . '">' . htmlentities(t($field)) . '</a>';
+    }
 
-	print '</th>';
+    if ($sort == $field . ' asc' or $sort == $field . ' desc') {
+      print '</b>';
+    }
 
-}
+    print '</th>';
 
-print '</tr></thead><tbody>';
+  }
 
-// print documents as rows
-foreach ($results->response->docs as $doc) {
-	print '<tr>';
+  print '</tr></thead><tbody>';
 
-	print '<td><ul>';
-	// highlightings (matching parts of content)
-	$id = $doc->id;
+  // print documents as rows
+  foreach ($results->response->docs as $doc) {
+    print '<tr>';
 
-	$highlightfield = 'content';
+    print '<td><ul>';
+    // highlightings (matching parts of content)
+    $id = $doc->id;
 
-	// if highligting available for the language, use highlighted content
-	foreach ($cfg['languages'] as $language) {
-		$language_specific_fieldname = 'content_txt_'.$language;
-		if (isset($results->highlighting->$id->$language_specific_fieldname)) {
-	    	$highlightfield = $language_specific_fieldname;
-	  	}
- 	}
+    $highlightfield = 'content';
 
-	if (isset($results->highlighting->$id->$highlightfield)) {
-		foreach ($results->highlighting->$id->$highlightfield as $snippet) {
-			print '<li class="snippet">' . $snippet . '</li>';
-		}	
-	}
+    // if highligting available for the language, use highlighted content
+    foreach ($cfg['languages'] as $language) {
+      $language_specific_fieldname = 'content_txt_' . $language;
+      if (isset($results->highlighting->$id->$language_specific_fieldname)) {
+        $highlightfield = $language_specific_fieldname;
+      }
+    }
 
-	print '</ul></td>';
-	
-	foreach ($fields as $field) {
-		print '<td>';
-		if (isset($doc->$field)) {
-						
-			if ( is_array ( $doc->$field ) ) {
-				foreach ($doc->$field as $value) {
-					print '<li>' . htmlspecialchars($value) . '</li>';
-				}
-					
-			} 
-			else {
-				print htmlspecialchars($doc->$field);
-			}
-		
-		}
-		print '</td>';
-	}
-	
-	
-	print '</tr>';
-}
+    if (isset($results->highlighting->$id->$highlightfield)) {
+      foreach ($results->highlighting->$id->$highlightfield as $snippet) {
+        print '<li class="snippet">' . $snippet . '</li>';
+      }
+    }
 
-print '</tbody></table>';
-?>
+    print '</ul></td>';
+
+    foreach ($fields as $field) {
+      print '<td>';
+      if (isset($doc->$field)) {
+
+        if (is_array($doc->$field)) {
+          foreach ($doc->$field as $value) {
+            print '<li>' . htmlspecialchars($value) . '</li>';
+          }
+
+        }
+        else {
+          print htmlspecialchars($doc->$field);
+        }
+
+      }
+      print '</td>';
+    }
+
+
+    print '</tr>';
+  }
+
+  print '</tbody></table>';
+  ?>
 
 </div>

--- a/src/templates/view.trend.php
+++ b/src/templates/view.trend.php
@@ -4,7 +4,7 @@
 ?>
 
 
-<?php 
+<?php
 // Include libs
 ?>
 
@@ -13,82 +13,88 @@
 <link href="nvd/nv.d3.css" rel="stylesheet">
 
 
-
-
-<?php 
+<?php
 
 // Page
 
 if ($date_label) {
-	echo '<h1>' . $date_label . '</h1>';
+  echo '<h1>' . $date_label . '</h1>';
 }
-	
-	?>
+
+?>
 
 <div id='chart'>
   <svg style='height:500px;'></svg>
 </div>
 
-    
 
-<?php 
+<?php
 
 // Init with size parameters
 
 ?>
 <script type="text/javascript">
-nv.addGraph(function() {
-	  var chart = nv.models.discreteBarChart()
-	      .x(function(d) { return d.label })    //Specify the data accessors.
-	      .y(function(d) { return d.value })
-	      .staggerLabels(true)    //Too many bars and not enough room? Try staggering labels.
-	      .tooltips(false)        //Don't show tooltips
-	      .showValues(true)       //...instead, show the bar value right on top of each bar.
-	      .transitionDuration(350)
-	      ;
+  nv.addGraph(function () {
+    var chart = nv.models.discreteBarChart()
+      .x(function (d) {
+        return d.label
+      })    //Specify the data accessors.
+      .y(function (d) {
+        return d.value
+      })
+      .staggerLabels(true)    //Too many bars and not enough room? Try staggering labels.
+      .tooltips(false)        //Don't show tooltips
+      .showValues(true)       //...instead, show the bar value right on top of each bar.
+      .transitionDuration(350)
+    ;
 
-	  d3.select('#chart svg')
-	      .datum(Data())
-	      .call(chart);
+    d3.select('#chart svg')
+      .datum(Data())
+      .call(chart);
 
-	  nv.utils.windowResize(chart.update);
+    nv.utils.windowResize(chart.update);
 
-	  return chart;
-	});
+    return chart;
+  });
 
-	//Each bar represents a single discrete quantity.
-	function Data() {
-	 return  [ 
-	    {
-	      key: "Cumulative Return",
-	      values: [
+  //Each bar represents a single discrete quantity.
+  function Data() {
+    return [
+      {
+        key: "Cumulative Return",
+        values: [
 
 
 
-<?php
+          <?php
 
-// Data2JSON
+          // Data2JSON
 
-	$first = true;
+          $first = TRUE;
 
-	foreach ($datevalues as $value) {
-	
-		// todo: link the chart
-		$link = '';
-			 
- 		// if not first entry, print delimiting comma
- 		if ($first) { $first = false; } else {print ",\n"; }
- 	
- 		print '{ "label": "' . $value['label' ]. '", "value": ' . $value['count'] . ', "link": "'.$value['link'].'" }';
- 	}
-?>
+          foreach ($datevalues as $value) {
 
-	               
-	      ]
-	    }
-	  ]
+            // todo: link the chart
+            $link = '';
 
-	}
+            // if not first entry, print delimiting comma
+            if ($first) {
+              $first = FALSE;
+            }
+            else {
+              print ",\n";
+            }
+
+            print '{ "label": "' . $value['label'] . '", "value": ' . $value['count'] . ', "link": "' . $value['link'] . '" }';
+          }
+          ?>
+
+
+        ]
+      }
+    ]
+
+  }
 
 
 </script>

--- a/src/templates/view.videos.php
+++ b/src/templates/view.videos.php
@@ -7,113 +7,120 @@
 
 <div id="results" class="row">
 
-<ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-2">
+  <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-2">
 
-<?php
-foreach ($results->response->docs as $doc) {
+    <?php
+    foreach ($results->response->docs as $doc) {
 
-  // URI
-  if (isset($doc->container_s)) {
-  	$id = $doc->container_s;
-  }
-  else {
-  	$id = $doc->id;
-  }
-  
-  
-  $uri_label = htmlspecialchars($id);
-  $uri_tip = false;
-  
-  // if file:// then only filename
-  if (strpos ($id, "file://")==0) {
-  	$uri_label = htmlspecialchars(basename($id));
-  	// for tooptip remove file:// from beginning
-  	$uri_tip = htmlspecialchars(substr( $id, 7 ));
-  }
-  
-  // Author
-  $author = htmlspecialchars($doc->author_s);
-
-  // Title
-  $title = false;
-  
-  if (isset($doc->title)) {
-    if (!empty($doc->title)) {
-    	$title= htmlspecialchars($doc->title);
-    }
-  }
-
-  // Type
-  $type= $doc->content_type;
-
-  // Modified date
-  if (isset($doc->file_modified_dt)) {
-	$datetime = $doc->file_modified_dt; 
-  } elseif (isset($doc->last_modified)) {
-  	$datetime = $doc->last_modified;
-  } else {
-  	$datetime=false;
-  }
+      // URI
+      if (isset($doc->container_s)) {
+        $id = $doc->container_s;
+      }
+      else {
+        $id = $doc->id;
+      }
 
 
-  // Snippet
-  if (isset($results->highlighting->$id->content)) {
-    $snippet = $results->highlighting->$id->content[0];
-  } else {
-	$snippet = $doc->content;
-	if (strlen($snippet) > $snippetsize) {
-		$snippet = substr($snippet,0,$snippetsize)."...";
-		$snippet = htmlspecialchars($snippet);
-	}
-  }
+      $uri_label = htmlspecialchars($id);
+      $uri_tip = FALSE;
 
-?>
-<li>
+      // if file:// then only filename
+      if (strpos($id, "file://") == 0) {
+        $uri_label = htmlspecialchars(basename($id));
+        // for tooptip remove file:// from beginning
+        $uri_tip = htmlspecialchars(substr($id, 7));
+      }
 
-	<div class="title">
-		<a class="title" target="_blank" href="<?=$id?>">
-				<?php if ($title) { ?>
-			<?=$title ?>
+      // Author
+      $author = htmlspecialchars($doc->author_s);
+
+      // Title
+      $title = FALSE;
+
+      if (isset($doc->title)) {
+        if (!empty($doc->title)) {
+          $title = htmlspecialchars($doc->title);
+        }
+      }
+
+      // Type
+      $type = $doc->content_type;
+
+      // Modified date
+      if (isset($doc->file_modified_dt)) {
+        $datetime = $doc->file_modified_dt;
+      }
+      elseif (isset($doc->last_modified)) {
+        $datetime = $doc->last_modified;
+      }
+      else {
+        $datetime = FALSE;
+      }
+
+
+      // Snippet
+      if (isset($results->highlighting->$id->content)) {
+        $snippet = $results->highlighting->$id->content[0];
+      }
+      else {
+        $snippet = $doc->content;
+        if (strlen($snippet) > $snippetsize) {
+          $snippet = substr($snippet, 0, $snippetsize) . "...";
+          $snippet = htmlspecialchars($snippet);
+        }
+      }
+
+      ?>
+      <li>
+
+        <div class="title">
+          <a class="title" target="_blank" href="<?= $id ?>">
+            <?php if ($title) { ?>
+              <?= $title ?>
+            <?php } ?>
+
+          </a>
+        </div>
+
+        <?php if ($uri_tip) { ?><span class="uri">
+					<span data-tooltip class="has-tip" title="<?= $uri_tip ?>">
 				<?php } ?>
-				
-		</a>
-	</div>
-
-						<?php if ($uri_tip) { ?><span class="uri">
-					<span data-tooltip class="has-tip" title="<?=$uri_tip?>">
-				<?php } ?>
-			<?=$uri_label?>
-				<?php if ($uri_tip) { ?>
+        <?= $uri_label ?>
+        <?php if ($uri_tip) { ?>
 					</span></span>
-				<?php } ?>
-	
+      <?php } ?>
 
-	
 
-	<div class="video">
-			
-<video controls src="<?=$id?>"></video>
+        <div class="video">
 
-	</div>
-	
-	
-	<div class="row">
-		<div class="date small-8 columns"><?=$datetime?></div>
-		<div class="size small-4 columns"><?=$file_size_txt?></div>	
-	</div>
-	
-	<div class="snippet">
-		<?php if ($author) { print '<div class="author">'.$author.'</div>:'; } ?>
-<?=$snippet?>
-	</div>
-	<div class="commands">
-			<a target="_blank" href="<?=$id?>"><?php echo t('open'); ?></a> <?php if ($cfg['metadata']['server']) { ?> | <a target="_blank" title="<?php echo t('meta description'); ?>" href="<?php print get_metadata_uri ($cfg['metadata']['server'], $id); ?>"><?php echo t('meta'); ?></a> <?php } ?> | <?php print '<a target="_blank" href="preview.php?id='.urlencode($id).'">' . t('Preview') . '</a>'; ?>
-	</div>
-</li>
+          <video controls src="<?= $id ?>"></video>
 
-<?php
-  } // foreach doc
-?>
+        </div>
 
-    </ul>
+
+        <div class="row">
+          <div class="date small-8 columns"><?= $datetime ?></div>
+          <div class="size small-4 columns"><?= $file_size_txt ?></div>
+        </div>
+
+        <div class="snippet">
+          <?php if ($author) {
+            print '<div class="author">' . $author . '</div>:';
+          } ?>
+          <?= $snippet ?>
+        </div>
+        <div class="commands">
+          <a target="_blank"
+             href="<?= $id ?>"><?php echo t('open'); ?></a> <?php if ($cfg['metadata']['server']) { ?> |
+            <a target="_blank" title="<?php echo t('meta description'); ?>"
+               href="<?php print get_metadata_uri($cfg['metadata']['server'], $id); ?>"><?php echo t('meta'); ?></a> <?php } ?>
+          | <?php print '<a target="_blank" href="preview.php?id=' . urlencode($id) . '">' . t('Preview') . '</a>'; ?>
+        </div>
+      </li>
+
+      <?php
+    } // foreach doc
+    ?>
+
+  </ul>
 </div>

--- a/src/templates/view.words.php
+++ b/src/templates/view.words.php
@@ -31,7 +31,6 @@
           print ",\n";
         }
 
-
         print '{ "text": "' . $word . '", "size": ' . $count . ', "link": "' . $wordlink . '" }';
       }
       ?>

--- a/src/templates/view.words.php
+++ b/src/templates/view.words.php
@@ -4,77 +4,90 @@
 
 <div id="results" class="row">
 
-<div class="row">
-<i>Documents: <?=$total?></i>
-</div>
+  <div class="row">
+    <i>Documents: <?= $total ?></i>
+  </div>
 
 
-<div  id="wordcloud" class="small-12 columns">
-</div>
-
-    
-    
-<script type="text/javascript">
-
-var words = [
-
-<?php
-	$first = true;
- 	foreach ($results->facet_counts->facet_fields->_text_ as $word=>$count) {
-
- 		$wordlink = buildurl_addvalue($params, '_text_', $word, 's', 1);
- 		 		 
- 		// if not first entry, print delimiting comma
- 		if ($first) { $first = false; } else {print ",\n"; }
-
- 	
- 		print '{ "text": "' . $word . '", "size": ' . $count . ', "link": "'.$wordlink.'" }';
- 	}
-?>
-];
-
-</script>
+  <div id="wordcloud" class="small-12 columns">
+  </div>
 
 
-<script src="d3js/d3.min.js" charset="utf-8"></script>
-<script src="d3js/d3.layout.cloud.js"></script>
+  <script type="text/javascript">
 
-<script type="text/javascript">
+    var words = [
 
-var size = [500, 600];
+      <?php
+      $first = TRUE;
+      foreach ($results->facet_counts->facet_fields->_text_ as $word => $count) {
 
-var fontSize = d3.scale.log().range([10, 30]);
+        $wordlink = buildurl_addvalue($params, '_text_', $word, 's', 1);
 
-d3.layout.cloud().size(size)
-	.words(words)
-	.fontSize(function(d) { return fontSize(+d.size); })
-	.rotate(function() { return 0 })
-	.on("end", draw)
-	.start();
+        // if not first entry, print delimiting comma
+        if ($first) {
+          $first = FALSE;
+        }
+        else {
+          print ",\n";
+        }
 
 
-function draw(words) {
-	d3.select("#wordcloud").append("svg")
-	.attr("width", size[0])
-	.attr("height", size[1])
-	.append("g")
-	.attr("transform", "translate(" + (size[0]/2) + "," + (size[1]/2) + ")")
-	.selectAll("text")
-	.data(words)
-	.enter()
-	.append("text")
-	.style("font-size", function(d) { return d.size + "px"; })
-	.attr("text-anchor", "middle")
-	.attr("transform", function(d) {
-			return "translate(" + [d.x, d.y] + ")rotate(" + d.rotate + ")";
-		})
-	.attr("onclick", function(d) {return "{waiting_on(); location.href='" + d.link + "';}";} )
-	.text(function(d) { return d.text; })
-	
-  }
-  
-    
+        print '{ "text": "' . $word . '", "size": ' . $count . ', "link": "' . $wordlink . '" }';
+      }
+      ?>
+    ];
 
-</script>
+  </script>
+
+
+  <script src="d3js/d3.min.js" charset="utf-8"></script>
+  <script src="d3js/d3.layout.cloud.js"></script>
+
+  <script type="text/javascript">
+
+    var size = [500, 600];
+
+    var fontSize = d3.scale.log().range([10, 30]);
+
+    d3.layout.cloud().size(size)
+      .words(words)
+      .fontSize(function (d) {
+        return fontSize(+d.size);
+      })
+      .rotate(function () {
+        return 0
+      })
+      .on("end", draw)
+      .start();
+
+
+    function draw(words) {
+      d3.select("#wordcloud").append("svg")
+        .attr("width", size[0])
+        .attr("height", size[1])
+        .append("g")
+        .attr("transform", "translate(" + (size[0] / 2) + "," + (size[1] / 2) + ")")
+        .selectAll("text")
+        .data(words)
+        .enter()
+        .append("text")
+        .style("font-size", function (d) {
+          return d.size + "px";
+        })
+        .attr("text-anchor", "middle")
+        .attr("transform", function (d) {
+          return "translate(" + [d.x, d.y] + ")rotate(" + d.rotate + ")";
+        })
+        .attr("onclick", function (d) {
+          return "{waiting_on(); location.href='" + d.link + "';}";
+        })
+        .text(function (d) {
+          return d.text;
+        })
+
+    }
+
+
+  </script>
 
 </div>


### PR DESCRIPTION
Apologies for a mega-pull. I have tried to keep the individual commits distinct.

Overall,
 - some reformatting of the templates, which had got a bit random;
 - using t() more often;
 - follow suggestions to use __DIR__ in apache solr lib;
 - use 'template-php' (if... endif) in templates roughly in Drupal style;
 - simplify logic a lot;
 - add a couple of calls to htmlspecialchars() that seemed to be needed.

A few functional changes:
 - For list view use the filename if we have no title to avoid a page of 'no title';
 - Remove target=blank - makes navigation much harder than needed;
 - Fix search options button (for me at least wasn't working at all);
 - Fix sorting selector (ditto);

I am still unsure what to do about filenames/urls in general. relying on file: access doesn't work for me, so would like a mechanism to translate to e.g. specific http: on the server, or similar.
