### PR TITLE
Word cloud updates

### DIFF
--- a/src/templates/view.words.php
+++ b/src/templates/view.words.php
@@ -15,23 +15,16 @@ foreach ($words as &$word) {
 }
 ?>
 
-<div id="results" class="row">
+<script src="d3js/d3.min.js" charset="utf-8"></script>
+<script src="d3js/d3.layout.cloud.js" charset="utf-8"></script>
 
-  <div class="row">
+<div id="results" class="row">
+  <div class="doc-count">
     <i>Documents: <?= $total ?></i>
   </div>
 
-
   <div id="wordcloud" class="small-12 columns">
   </div>
-
-
-  <script type="text/javascript">
-  </script>
-
-
-  <script src="d3js/d3.min.js" charset="utf-8"></script>
-  <script src="d3js/d3.layout.cloud.js"></script>
 
   <script type="text/javascript">
 

--- a/src/templates/view.words.php
+++ b/src/templates/view.words.php
@@ -1,5 +1,18 @@
 <?php
 // Show results as word cloud
+$words = [];
+$total = 0;
+if (!empty($results->facet_counts->facet_fields)) {
+  foreach ($results->facet_counts->facet_fields->_text_ as $word => $count) {
+    $link = buildurl_addvalue($params, '_text_', $word, 's', 1);
+    $words[] = ['text' => $word, 'size' => $count, 'link' => $link];
+    $total += $count;
+  }
+}
+// Now we have a total count, make size a percentage.
+foreach ($words as &$word) {
+  $word['size'] = ceil(($word['size'] * 100) / $total);
+}
 ?>
 
 <div id="results" class="row">
@@ -14,28 +27,6 @@
 
 
   <script type="text/javascript">
-
-    var words = [
-
-      <?php
-      $first = TRUE;
-      foreach ($results->facet_counts->facet_fields->_text_ as $word => $count) {
-
-        $wordlink = buildurl_addvalue($params, '_text_', $word, 's', 1);
-
-        // if not first entry, print delimiting comma
-        if ($first) {
-          $first = FALSE;
-        }
-        else {
-          print ",\n";
-        }
-
-        print '{ "text": "' . $word . '", "size": ' . $count . ', "link": "' . $wordlink . '" }';
-      }
-      ?>
-    ];
-
   </script>
 
 
@@ -47,6 +38,7 @@
     var size = [500, 600];
 
     var fontSize = d3.scale.log().range([10, 30]);
+    var words = <?= json_encode($words); ?>;
 
     d3.layout.cloud().size(size)
       .words(words)


### PR DESCRIPTION
For me the word cloud was a bit of a mess, with all words displayed max size, which turned out to be fixed by making the word counts proportional (in this case percentage) rather than absolute.

This patch fixes the issue and reworks the code to use json_encode so as to avoid the need to print formatted objects by hand. It also addresses the Document count text being class 'row' even though it was within a div class row already; I think this is a good thing?

Finally I have moved the remote script tags out of the div.row because the .row class was adding :after to the scripts. Probably not an issue but it seemed cleaner this way.