### PR TITLE
omit all subsequent zero-values since 1980

### DIFF
--- a/src/templates/view.trend.php
+++ b/src/templates/view.trend.php
@@ -71,8 +71,12 @@ if ($date_label) {
           // Data2JSON
 
           $first = TRUE;
-
+          $pre_val = 0;
           foreach ($datevalues as $value) {
+            if($value['count'] == $pre_val){
+								$prev_val = $value['count'];
+								continue;
+							}
 
             // todo: link the chart
             $link = '';


### PR DESCRIPTION
Hi
for my first contribution, I'd like to implement a minor change in the Trend chart, to omit beginning zero-values right up to where there is actually data to display.
In my case, I was plotting always right from 1980-2012, although there was nothing to plot.

best regards from Switzerland

For tl;dr:
![bildschirmfoto 2018-06-19 um 09 28 30](https://user-images.githubusercontent.com/26161943/41582902-2b5ccc50-73a3-11e8-8f58-a3236aa65a26.png)
![bildschirmfoto 2018-06-19 um 09 28 23](https://user-images.githubusercontent.com/26161943/41582903-2b7b0dfa-73a3-11e8-89d5-93b3efa7968d.png)

