### PR TITLE
Fix warning in src/templates/view.*

### DIFF
--- a/src/templates/view.audios.php
+++ b/src/templates/view.audios.php
@@ -39,7 +39,7 @@
 
       if (isset($doc->title_txt)) {
         if (!empty($doc->title_txt)) {
-          $title = htmlspecialchars($doc->title_txt);
+          $title = htmlspecialchars(implode(", ", $doc->title_txt));
         }
       }
 

--- a/src/templates/view.images.php
+++ b/src/templates/view.images.php
@@ -34,7 +34,7 @@
       $title = FALSE;
 
       if (!empty($doc->title_txt)) {
-        $title = htmlspecialchars($doc->title_txt);
+        $title = htmlspecialchars(implode(", ", $doc->title_txt));
       }
 
       // Type

--- a/src/templates/view.list.php
+++ b/src/templates/view.list.php
@@ -196,7 +196,7 @@ function get_snippets($result_nr, $snippets) {
       // $title = t('No title');
       $title = $uri_label;
       if (!empty($doc->title_txt)) {
-        $title = htmlspecialchars($doc->title_txt);
+        $title = htmlspecialchars(implode(", ", $doc->title_txt));
       }
 
       // Modified date

--- a/src/templates/view.preview.php
+++ b/src/templates/view.preview.php
@@ -118,7 +118,7 @@ if (is_array($doc->author_ss)) {
 $title = t("No Title");
 if (isset($doc->title_txt)) {
   if (!empty($doc->title_txt)) {
-    $title = htmlspecialchars($doc->title_txt);
+    $title = htmlspecialchars(implode(", ", $doc->title_txt));
   }
 }
 

--- a/src/templates/view.rss.php
+++ b/src/templates/view.rss.php
@@ -62,7 +62,7 @@ foreach ($results->response->docs as $doc) {
       // Title
       $title = $uri_label;
       if (!empty($doc->title_txt)) {
-        $title = $doc->title_txt;
+        $title = htmlspecialchars(implode(", ", $doc->title_txt));
       }
 
       // Modified date

--- a/src/templates/view.videos.php
+++ b/src/templates/view.videos.php
@@ -39,7 +39,7 @@
 
       if (isset($doc->title_txt)) {
         if (!empty($doc->title_txt)) {
-          $title = htmlspecialchars($doc->title_txt);
+          $title = htmlspecialchars(implode(", ", $doc->title_txt));
         }
       }
 


### PR DESCRIPTION
This fixes a warning which occurs when title_txt is an array.
Example:
Warning: htmlspecialchars() expects parameter 1 to be string, array given in /usr/share/solr-php-ui/templates/view.videos.php on line 42

The fix is, to implode the array with a glue string ", ".
Please let me know if you want to change the glue string to something else, or if you propose a different fix!