### PR TITLE
Fix warning in src/templates/view.* (2nd attempt)

### DIFF
--- a/src/templates/helpers.php
+++ b/src/templates/helpers.php
@@ -1,0 +1,10 @@
+<?php
+function format_title($title_txt, $default=FALSE) {
+    if (!isset($title_txt) || empty($title_txt))
+        return $default;
+    if(is_array($title_txt)) {
+        $title_txt = implode(", ", $title_txt);
+    }
+    return htmlspecialchars($title_txt);
+}
+?>

--- a/src/templates/view.audios.php
+++ b/src/templates/view.audios.php
@@ -3,6 +3,7 @@
 //
 // Show results as list
 
+require_once(__DIR__ . '/helpers.php');
 ?>
 
 <div id="results" class="row">
@@ -35,13 +36,7 @@
       $author = htmlspecialchars($doc->author_s);
 
       // Title
-      $title = FALSE;
-
-      if (isset($doc->title_txt)) {
-        if (!empty($doc->title_txt)) {
-          $title = htmlspecialchars(implode(", ", $doc->title_txt));
-        }
-      }
+      $title = format_title($doc->title_txt);
 
       // Type
       $type = $doc->content_type_ss;

--- a/src/templates/view.images.php
+++ b/src/templates/view.images.php
@@ -2,6 +2,7 @@
 // Standard view
 //
 // Show results as images
+require_once(__DIR__ . '/helpers.php');
 ?>
 
 <div id="results" class="row">
@@ -31,11 +32,7 @@
       $author = htmlspecialchars($doc->author_ss);
 
       // Title
-      $title = FALSE;
-
-      if (!empty($doc->title_txt)) {
-        $title = htmlspecialchars(implode(", ", $doc->title_txt));
-      }
+      $title = format_title($doc->title_txt);
 
       // Type
       $type = $doc->content_type_ss;

--- a/src/templates/view.list.php
+++ b/src/templates/view.list.php
@@ -3,6 +3,8 @@
 //
 
 // Number of snippets initially displayed.
+require_once(__DIR__ . '/helpers.php');
+
 define('SNIPPETS_OPEN', 3);
 
 function get_facets($result_nr, $doc, $facet_cfg /*=$cfg['facets']*/) {
@@ -193,11 +195,7 @@ function get_snippets($result_nr, $snippets) {
 		
 		
       // Title
-      // $title = t('No title');
-      $title = $uri_label;
-      if (!empty($doc->title_txt)) {
-        $title = htmlspecialchars(implode(", ", $doc->title_txt));
-      }
+      $title = format_title($doc->title_txt, $uri_label);
 
       // Modified date
       $datetime = FALSE;

--- a/src/templates/view.preview.php
+++ b/src/templates/view.preview.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once(__DIR__ . '/helpers.php');
+
 // Show preview
 
 
@@ -115,12 +117,7 @@ if (is_array($doc->author_ss)) {
 }
 
 // Title
-$title = t("No Title");
-if (isset($doc->title_txt)) {
-  if (!empty($doc->title_txt)) {
-    $title = htmlspecialchars(implode(", ", $doc->title_txt));
-  }
-}
+$title = format_title($doc->title_txt, t("No Title"));
 
 // Modified date
 if (isset($doc->file_modified_dt)) {

--- a/src/templates/view.rss.php
+++ b/src/templates/view.rss.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/helpers.php');
 
 //
 // Search results as RSS Feed
@@ -60,10 +61,7 @@ foreach ($results->response->docs as $doc) {
       $author = $doc->author_ss;
 
       // Title
-      $title = $uri_label;
-      if (!empty($doc->title_txt)) {
-        $title = htmlspecialchars(implode(", ", $doc->title_txt));
-      }
+      $title = format_title($doc->title_txt, $uri_label);
 
       // Modified date
       $datetime = FALSE;

--- a/src/templates/view.videos.php
+++ b/src/templates/view.videos.php
@@ -2,7 +2,7 @@
 // Standard view
 //
 // Show results as list
-
+require_once(__DIR__ . '/helpers.php');
 ?>
 
 <div id="results" class="row">
@@ -35,13 +35,7 @@
       $author = htmlspecialchars($doc->author_ss);
 
       // Title
-      $title = FALSE;
-
-      if (isset($doc->title_txt)) {
-        if (!empty($doc->title_txt)) {
-          $title = htmlspecialchars(implode(", ", $doc->title_txt));
-        }
-      }
+      $title = format_title($doc->title_txt);
 
       // Type
       $type = $doc->content_type_ss;


### PR DESCRIPTION
My previous commit introduced a new warning (in the case, where title_txt is not an array).
With this commit, both cases should be covered.