### PR TITLE
get_magic_quotes has been removed from PHP, as can be seen here:

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -892,11 +892,6 @@ if ($cfg['etl_status_warning']) {
 	}
 }
 
-// if magic quotes is enabled then stripslashes will be needed
-if (get_magic_quotes_gpc() == 1) {
-	$query = stripslashes($query);
-}
-
 // If no query, so show last documents
 if (!$query) {
 	if ($cfg['newest_on_empty_query']) {

--- a/src/jquery/jquery-ui-1.9.2.custom/development-bundle/demos/autocomplete/search.php
+++ b/src/jquery/jquery-ui-1.9.2.custom/development-bundle/demos/autocomplete/search.php
@@ -4,8 +4,6 @@ sleep( 3 );
 // no term passed - just exit early with no response
 if (empty($_GET['term'])) exit ;
 $q = strtolower($_GET["term"]);
-// remove slashes if they were magically added
-if (get_magic_quotes_gpc()) $q = stripslashes($q);
 
 $items = array(
 "Great Bittern"=>"Botaurus stellaris",


### PR DESCRIPTION
This check has been removed: https://www.php.net/manual/en/function.get-magic-quotes-gpc.php and for good reason: the configuration setting it should report on, has been removed even earlier: in PHP 5.4.0: https://www.php.net/releases/5_4_0.php or about 10 years ago.

So this check serves no purpose - it has been returning `false` for 10 years.

Closes #71